### PR TITLE
Update gemspec

### DIFF
--- a/buildkite-builder.gemspec
+++ b/buildkite-builder.gemspec
@@ -24,9 +24,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "bin/**/*"]
   spec.executables   = ['buildkite-builder']
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This PR updates the gemspec:
* Adds a summary and description
* Changes the gemspec files
```ruby
# the delta between the gemspec files code, these files are no longer being included
[".gitignore", ".rspec", "CODE_OF_CONDUCT.md", "Gemfile", "Gemfile.lock", "Rakefile", "buildkite-builder.gemspec"]
```