### PR TITLE
Add Context for Pipeline building

### DIFF
--- a/lib/buildkite/builder.rb
+++ b/lib/buildkite/builder.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'bundler'
 require 'pathname'
 
 module Buildkite
   module Builder
     autoload :Commands, File.expand_path('builder/commands', __dir__)
+    autoload :Context, File.expand_path('builder/context', __dir__)
     autoload :Definition, File.expand_path('builder/definition', __dir__)
     autoload :FileResolver, File.expand_path('builder/file_resolver', __dir__)
     autoload :Github, File.expand_path('builder/github', __dir__)
@@ -16,13 +16,23 @@ module Buildkite
     autoload :Rainbow, File.expand_path('builder/rainbow', __dir__)
     autoload :Runner, File.expand_path('builder/runner', __dir__)
 
-    BUILDKITE_DIRECTORY_NAME = '.buildkite/'
+    BUILDKITE_DIRECTORY_NAME = Pathname.new('.buildkite').freeze
 
     class << self
       def root(start_path: Dir.pwd, reset: false)
         @root = nil if reset
         @root ||= find_buildkite_directory(start_path)
       end
+
+      def template(&block)
+        Definition::Template.new(&block) if block_given?
+      end
+
+      def pipeline(&block)
+        Definition::Pipeline.new(&block) if block_given?
+      end
+
+      private
 
       def find_buildkite_directory(start_path)
         path = Pathname.new(start_path)
@@ -34,18 +44,6 @@ module Buildkite
         path.expand_path
       end
 
-      def expand_path(path)
-        path = Pathname.new(path)
-        path.absolute? ? path : root.join(path)
-      end
-
-      def template(&block)
-        Definition::Template.new(&block) if block_given?
-      end
-
-      def pipeline(&block)
-        Definition::Pipeline.new(&block) if block_given?
-      end
     end
   end
 end

--- a/lib/buildkite/builder/commands/abstract.rb
+++ b/lib/buildkite/builder/commands/abstract.rb
@@ -56,7 +56,7 @@ module Buildkite
         end
 
         def pipelines_path
-          Buildkite::Builder.root.join(Runner::PIPELINES_PATH)
+          Builder.root.join(Builder::BUILDKITE_DIRECTORY_NAME).join(Runner::PIPELINES_PATH)
         end
       end
     end

--- a/lib/buildkite/builder/commands/preview.rb
+++ b/lib/buildkite/builder/commands/preview.rb
@@ -9,19 +9,21 @@ module Buildkite
         self.description = 'Outputs the pipeline YAML.'
 
         def run
-          unless pipeline
-            raise 'You must specify a pipeline'
+          pipeline = ARGV.last
+
+          if !pipeline && !root_pipeline?
+            if available_pipelines.one?
+              pipeline = available_pipelines.first
+            else
+              raise 'You must specify a pipeline'
+            end
           end
 
           puts Runner.new(pipeline: pipeline).run.to_yaml
         end
 
-        def pipeline
-          @pipeline ||= ARGV.last || begin
-            if available_pipelines.one?
-              available_pipelines.first
-            end
-          end
+        def root_pipeline?
+          pipelines_path.join(Context::PIPELINE_DEFINITION_FILE).exist?
         end
       end
     end

--- a/lib/buildkite/builder/commands/run.rb
+++ b/lib/buildkite/builder/commands/run.rb
@@ -9,7 +9,17 @@ module Buildkite
         self.description = 'Builds and uploads the generated pipeline.'
 
         def run
-          Builder::Runner.run
+          # This entrypoint is for running on CI. It expects certain environment
+          # variables to be set.
+          options = {
+            upload: true
+          }
+
+          if available_pipelines.include?(Buildkite.env.pipeline_slug)
+            options[:pipeline] = Buildkite.env.pipeline_slug
+          end
+
+          Builder::Runner.new(**options).run
         end
       end
     end

--- a/lib/buildkite/builder/context.rb
+++ b/lib/buildkite/builder/context.rb
@@ -21,13 +21,15 @@ module Buildkite
       end
 
       def build
-        @pipeline = Pipelines::Pipeline.new
+        unless @pipeline
+          @pipeline = Pipelines::Pipeline.new
 
-        load_manifests
-        load_templates
-        load_processors
-        load_pipeline
-        run_processors
+          load_manifests
+          load_templates
+          load_processors
+          load_pipeline
+          run_processors
+        end
 
         @pipeline
       end

--- a/lib/buildkite/builder/context.rb
+++ b/lib/buildkite/builder/context.rb
@@ -1,0 +1,67 @@
+module Buildkite
+  module Builder
+    class Context
+      include Definition::Helper
+
+      PIPELINE_DEFINITION_FILE = Pathname.new('pipeline.rb').freeze
+
+      attr_reader :logger
+      attr_reader :root
+
+      def self.build(root, logger: nil)
+        context = new(root, logger: logger)
+        context.build
+        context
+      end
+
+      def initialize(root, logger: nil)
+        @root = root
+        @logger = logger || Logger.new(File::NULL)
+      end
+
+      def build
+        load_manifests
+        load_templates
+        load_processors
+        load_pipeline
+        run_processors
+      end
+
+      def pipeline
+        @pipeline ||= Pipelines::Pipeline.new
+      end
+
+      private
+
+      def load_manifests
+        Loaders::Manifests.load(root).each do |name, asset|
+          Manifest[name] = asset
+        end
+      end
+
+      def load_templates
+        Loaders::Templates.load(root).each do |name, asset|
+          pipeline.template(name, &asset)
+        end
+      end
+
+      def load_processors
+        Loaders::Processors.load(root)
+      end
+
+      def run_processors
+        pipeline.processors.each do |processor|
+          processor.process(self)
+        end
+      end
+
+      def load_pipeline
+        pipeline.instance_eval(&pipeline_definition)
+      end
+
+      def pipeline_definition
+        @pipeline_definition ||= load_definition(root.join(PIPELINE_DEFINITION_FILE), Definition::Pipeline)
+      end
+    end
+  end
+end

--- a/lib/buildkite/builder/context.rb
+++ b/lib/buildkite/builder/context.rb
@@ -7,6 +7,7 @@ module Buildkite
 
       attr_reader :logger
       attr_reader :root
+      attr_reader :pipeline
 
       def self.build(root, logger: nil)
         context = new(root, logger: logger)
@@ -20,15 +21,15 @@ module Buildkite
       end
 
       def build
+        @pipeline = Pipelines::Pipeline.new
+
         load_manifests
         load_templates
         load_processors
         load_pipeline
         run_processors
-      end
 
-      def pipeline
-        @pipeline ||= Pipelines::Pipeline.new
+        @pipeline
       end
 
       private

--- a/lib/buildkite/builder/loaders/abstract.rb
+++ b/lib/buildkite/builder/loaders/abstract.rb
@@ -5,14 +5,14 @@ module Buildkite
     module Loaders
       class Abstract
         attr_reader :assets
-        attr_reader :pipeline
+        attr_reader :root
 
-        def self.load(pipeline)
-          new(pipeline).assets
+        def self.load(root)
+          new(root).assets
         end
 
-        def initialize(pipeline)
-          @pipeline = pipeline
+        def initialize(root)
+          @root = root
           @assets = {}
           load
         end
@@ -20,11 +20,7 @@ module Buildkite
         private
 
         def buildkite_path
-          Buildkite::Builder.root.join('.buildkite')
-        end
-
-        def pipeline_path
-          buildkite_path.join("pipelines/#{pipeline}")
+          Builder.root.join(Builder::BUILDKITE_DIRECTORY_NAME)
         end
 
         def load

--- a/lib/buildkite/builder/loaders/manifests.rb
+++ b/lib/buildkite/builder/loaders/manifests.rb
@@ -15,7 +15,7 @@ module Buildkite
         end
 
         def manifests_path
-          pipeline_path.join(MANIFESTS_PATH)
+          root.join(MANIFESTS_PATH)
         end
       end
     end

--- a/lib/buildkite/builder/loaders/processors.rb
+++ b/lib/buildkite/builder/loaders/processors.rb
@@ -19,7 +19,7 @@ module Buildkite
           return unless path.directory?
 
           path.children.map do |file|
-            required_status = require(file)
+            required_status = require(file.to_s)
             add(file.basename, { required: required_status })
           end
         end
@@ -29,7 +29,7 @@ module Buildkite
         end
 
         def pipeline_processors_path
-          pipeline_path.join(PROCESSORS_PATH)
+          root.join(PROCESSORS_PATH)
         end
       end
     end

--- a/lib/buildkite/builder/loaders/templates.rb
+++ b/lib/buildkite/builder/loaders/templates.rb
@@ -17,7 +17,7 @@ module Buildkite
         end
 
         def templates_path
-          pipeline_path.join(TEMPLATES_PATH)
+          root.join(TEMPLATES_PATH)
         end
       end
     end

--- a/lib/buildkite/builder/manifest.rb
+++ b/lib/buildkite/builder/manifest.rb
@@ -2,7 +2,7 @@
 
 require 'digest/md5'
 require 'pathname'
-require 'set'
+require 'sorted_set'
 
 module Buildkite
   module Builder

--- a/lib/buildkite/builder/processors/abstract.rb
+++ b/lib/buildkite/builder/processors/abstract.rb
@@ -7,12 +7,12 @@ module Buildkite
         include LoggingUtils
         using Rainbow
 
-        def self.process(runner)
-          new(runner).run
+        def self.process(context)
+          new(context).run
         end
 
-        def initialize(runner)
-          @runner = runner
+        def initialize(context)
+          @context = context
         end
 
         def run
@@ -21,18 +21,18 @@ module Buildkite
 
         private
 
-        attr_reader :runner
+        attr_reader :context
 
         def process
           raise NotImplementedError
         end
 
         def log
-          runner.log
+          context.logger
         end
 
         def pipeline
-          runner.pipeline
+          context.pipeline
         end
 
         def buildkite

--- a/lib/buildkite/builder/runner.rb
+++ b/lib/buildkite/builder/runner.rb
@@ -15,13 +15,12 @@ module Buildkite
 
       attr_reader :options
 
-
       def initialize(**options)
         @options = options
       end
 
       def run
-        log.info "#{'+++ ' if Buildkite.env}🧰 " + 'Buildkite-builder'.color(:springgreen) + " ─ #{@options[:pipeline].yellow}"
+        log.info "#{'+++ ' if Buildkite.env}🧰 " + 'Buildkite Builder'.color(:springgreen) + " ─ #{@options[:pipeline].yellow}"
         context = Context.new(root, logger: log)
 
         results = benchmark("\nDone (%s)".color(:springgreen)) do
@@ -37,6 +36,8 @@ module Buildkite
         context.pipeline
       end
 
+      private
+
       def log
         @log ||= begin
           Logger.new($stdout).tap do |logger|
@@ -46,8 +47,6 @@ module Buildkite
           end
         end
       end
-
-      private
 
       def upload(pipeline)
         Tempfile.create(['pipeline', '.yml']) do |file|

--- a/lib/buildkite/pipelines/pipeline.rb
+++ b/lib/buildkite/pipelines/pipeline.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'yaml'
+require 'pathname'
 
 module Buildkite
   module Pipelines

--- a/spec/buildkite/builder/context_spec.rb
+++ b/spec/buildkite/builder/context_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::Builder::Context do
+  before do
+    setup_project(fixture_project)
+  end
+  let(:fixture_project) { :basic }
+  let(:fixture_path) { fixture_pipeline_path_for(fixture_project, :dummy) }
+
+  describe '.build' do
+    it 'initializes and builds the pipeline' do
+      context = described_class.build(fixture_path)
+
+      expect(context).to be_a(Buildkite::Builder::Context)
+      expect(context.pipeline).to be_a(Buildkite::Pipelines::Pipeline)
+    end
+  end
+
+  describe '.new' do
+    it 'does not preemptively build the pipeline' do
+      context = described_class.new(fixture_path)
+
+      expect(context.pipeline).to be_nil
+    end
+
+    it 'sets attributes' do
+      logger = Logger.new(STDOUT)
+      context = described_class.new(fixture_path, logger: logger)
+
+      expect(context.root).to eq(fixture_path)
+      expect(context.logger).to eq(logger)
+    end
+  end
+
+  describe '#build' do
+    let(:fixture_project) { :basic_with_shared_and_pipeline_processors }
+    let(:context) { described_class.new(fixture_path) }
+
+    it 'is idempotent' do
+      pipeline = context.build
+
+      expect(context.build).to equal(pipeline)
+    end
+
+    it 'loads manifests' do
+      context.build
+      manifests = Buildkite::Builder::Manifest.manifests
+
+      expect(manifests.size).to eq(1)
+      expect(manifests).to have_key('basic')
+      expect(manifests['basic']).to be_a(Buildkite::Builder::Manifest)
+    end
+
+    it 'loads templates' do
+      pipeline = context.build
+      templates = pipeline.templates
+
+      expect(templates.size).to eq(1)
+      expect(templates).to have_key('basic')
+      expect(templates['basic']).to be_a(Buildkite::Builder::Definition::Template)
+    end
+
+    it 'loads processors' do
+      processors = context.build.processors
+
+      expect(processors.size).to eq(2)
+    end
+
+    it 'loads the pipeline' do
+      pipeline = YAML.load(context.build.to_yaml)
+
+      expect(pipeline.dig('steps', 0, 'label')).to eq('Basic step')
+    end
+
+    it 'runs the processors' do
+      steps = context.build.steps
+      steps_label_and_commands = steps.map { |step| [step.label, step.command] }
+
+      expect(steps_label_and_commands).to eq([
+        ['Basic step', ['true']],
+        ['Appended By Processors::PipelineSpecificProcessor', ['echo 1']],
+        ['Appended By Processors::SharedProcessor', ['echo 1']],
+      ])
+    end
+
+    it 'returns the pipeline' do
+      expect(context.build).to be_a(Buildkite::Pipelines::Pipeline)
+    end
+
+    context 'with an invalid pipeline' do
+      let(:fixture_project) { :invalid_pipeline }
+
+      it 'raises an error' do
+        expect {
+          context.build
+        }.to raise_error(/must return a valid definition \(Buildkite::Builder::Definition::Pipeline\)/)
+      end
+    end
+
+    context 'with an invalid step' do
+      let(:fixture_project) { :invalid_step }
+
+      it 'raises an error' do
+        expect {
+          context.build
+        }.to raise_error(/must return a valid definition \(Buildkite::Builder::Definition::Template\)/)
+      end
+    end
+  end
+end

--- a/spec/buildkite/builder/loaders/abstract_spec.rb
+++ b/spec/buildkite/builder/loaders/abstract_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Buildkite::Builder::Loaders::Abstract do
-  let(:pipeline) { 'dummy' }
+  let(:root) { fixture_pipeline_path_for(:basic, :dummy) }
+
   let(:foo_loader) do
     Class.new(Buildkite::Builder::Loaders::Abstract) do
       attr_reader :load_called
@@ -21,14 +22,14 @@ RSpec.describe Buildkite::Builder::Loaders::Abstract do
       assets = double
       foo_loader_instance = instance_double(foo_loader, assets: assets)
 
-      expect(foo_loader).to receive(:new).with(pipeline).and_return(foo_loader_instance)
-      expect(foo_loader.load(pipeline)).to eq(assets)
+      expect(foo_loader).to receive(:new).with(root).and_return(foo_loader_instance)
+      expect(foo_loader.load(root)).to eq(assets)
     end
   end
 
   describe '.new' do
     it 'calls the subclass load method' do
-      foo_loader_instance = foo_loader.new(pipeline)
+      foo_loader_instance = foo_loader.new(root)
 
       expect(foo_loader_instance.load_called).to eq(true)
     end
@@ -46,23 +47,23 @@ RSpec.describe Buildkite::Builder::Loaders::Abstract do
         Class.new(Buildkite::Builder::Loaders::Abstract) do
           def load
             add(:foo, 'foo')
-            add(:pipeline, pipeline)
+            add(:pipeline, 'dummy')
           end
         end
       end
 
       it 'returns a hash of loaded assets' do
-        assets = foo_loader.new(pipeline).assets
+        assets = foo_loader.new(root).assets
 
         expect(assets.size).to eq(2)
         expect(assets['foo']).to eq('foo')
-        expect(assets['pipeline']).to eq(pipeline)
+        expect(assets['pipeline']).to eq('dummy')
       end
     end
 
     context 'when there are no assets' do
       it 'returns an empty hash' do
-        assets = foo_loader.new(pipeline).assets
+        assets = foo_loader.new(root).assets
 
         expect(assets).to be_a(Hash)
         expect(assets).to be_empty
@@ -70,11 +71,11 @@ RSpec.describe Buildkite::Builder::Loaders::Abstract do
     end
   end
 
-  describe '#pipeline' do
+  describe '#root' do
     it 'returns the pipeline' do
-      foo_loader_instance = foo_loader.new(pipeline)
+      foo_loader_instance = foo_loader.new(root)
 
-      expect(foo_loader_instance.pipeline).to eq(pipeline)
+      expect(foo_loader_instance.root).to eq(root)
     end
   end
 end

--- a/spec/buildkite/builder/loaders/manifests_spec.rb
+++ b/spec/buildkite/builder/loaders/manifests_spec.rb
@@ -4,18 +4,19 @@ require 'fileutils'
 
 RSpec.describe Buildkite::Builder::Loaders::Manifests do
   describe '.load' do
-    let(:pipeline) { 'dummy' }
-
     context 'when manifests path exists' do
+      let(:root) { fixture_pipeline_path_for(:basic, :dummy) }
+
       before do
         setup_project(:basic)
       end
 
       it 'loads the manifests' do
-        Buildkite::Builder.root.join('basic').mkpath
-        FileUtils.touch(Buildkite::Builder.root.join('basic/foo.txt'))
+        project_root = fixture_path_for(:basic)
+        project_root.join('basic').mkpath
+        FileUtils.touch(project_root.join('basic/foo.txt'))
 
-        assets = described_class.load(pipeline)
+        assets = described_class.load(root)
         manifest = assets['basic']
 
         expect(assets.size).to eq(1)
@@ -27,12 +28,14 @@ RSpec.describe Buildkite::Builder::Loaders::Manifests do
     end
 
     context 'when manifests path does not exist' do
+      let(:root) { fixture_pipeline_path_for(:invalid_step, :dummy) }
+
       before do
         setup_project(:invalid_step)
       end
 
       it 'returns an empty hash' do
-        expect(described_class.load(pipeline)).to be_empty
+        expect(described_class.load(root)).to be_empty
       end
     end
   end

--- a/spec/buildkite/builder/loaders/processors_spec.rb
+++ b/spec/buildkite/builder/loaders/processors_spec.rb
@@ -2,39 +2,43 @@
 
 RSpec.describe Buildkite::Builder::Loaders::Processors do
   describe '.load' do
-    let(:pipeline) { 'dummy' }
-
     context 'when shared processors path exists' do
+      let(:root) { fixture_pipeline_path_for(:basic_with_processors, :dummy) }
+
       before do
         setup_project(:basic_with_processors)
       end
 
       it 'loads the processors' do
-        assets = described_class.load(pipeline)
+        assets = described_class.load(root)
 
         expect(assets.size).to eq(1)
       end
     end
 
     context 'when shared processors path and pipeline processors path exists' do
+      let(:root) { fixture_pipeline_path_for(:basic_with_shared_and_pipeline_processors, :dummy) }
+
       before do
         setup_project(:basic_with_shared_and_pipeline_processors)
       end
 
       it 'loads both processors' do
-        assets = described_class.load(pipeline)
+        assets = described_class.load(root)
 
         expect(assets.size).to eq(2)
       end
     end
 
     context 'when shared processors path does not exist' do
+      let(:root) { fixture_pipeline_path_for(:basic, :dummy) }
+
       before do
         setup_project(:basic)
       end
 
       it 'returns an empty hash' do
-        assets = described_class.load(pipeline)
+        assets = described_class.load(root)
 
         expect(assets).to be_empty
       end

--- a/spec/buildkite/builder/loaders/templates_spec.rb
+++ b/spec/buildkite/builder/loaders/templates_spec.rb
@@ -2,33 +2,35 @@
 
 RSpec.describe Buildkite::Builder::Loaders::Templates do
   describe '.load' do
-    let(:pipeline) { 'dummy' }
-
     context 'when templates path exists' do
+      let(:root) { fixture_pipeline_path_for(:basic, :dummy) }
+
       before do
         setup_project(:basic)
       end
 
       it 'loads the templates' do
-        assets = described_class.load(pipeline)
+        assets = described_class.load(root)
         template = assets['basic']
 
         expect(assets.size).to eq(1)
         expect(template).to be_a(Buildkite::Builder::Definition::Template)
 
-        step = Buildkite::Pipelines::Steps::Command.new(pipeline, template)
+        step = Buildkite::Pipelines::Steps::Command.new(instance_double(Buildkite::Pipelines::Pipeline), template)
         expect(step.label).to eq('Basic step')
         expect(step.command).to eq(['true'])
       end
     end
 
     context 'when templates path does not exist' do
+      let(:root) { fixture_pipeline_path_for(:invalid_pipeline, :dummy) }
+
       before do
         setup_project(:invalid_pipeline)
       end
 
       it 'returns an empty hash' do
-        expect(described_class.load(pipeline)).to be_empty
+        expect(described_class.load(root)).to be_empty
       end
     end
   end

--- a/spec/buildkite/builder/processors/abstract_spec.rb
+++ b/spec/buildkite/builder/processors/abstract_spec.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 RSpec.describe Buildkite::Builder::Processors::Abstract do
   let(:runner) do
-    instance_double(Buildkite::Builder::Runner, log: Logger.new)
+    instance_double(Buildkite::Builder::Context, logger: Logger.new)
   end
 
   describe '.process' do

--- a/spec/buildkite/builder/runner_spec.rb
+++ b/spec/buildkite/builder/runner_spec.rb
@@ -3,39 +3,6 @@
 require 'logger'
 
 RSpec.describe Buildkite::Builder::Runner do
-  describe '.run' do
-    before do
-      stub_buildkite_env(pipeline_slug: pipeline_slug)
-    end
-
-    let(:pipeline_slug) { 'dummy' }
-
-    it 'calls runner instance with prefilled arguments' do
-      runner = instance_double(described_class)
-      expect(runner).to receive(:run).once
-      expect(described_class).to receive(:new).with(
-        upload: true,
-        pipeline: pipeline_slug
-      ).and_return(runner)
-
-      described_class.run
-    end
-  end
-
-  describe '#pipeline_definition' do
-    let(:pipeline_name) { 'dummy' }
-    let(:options) { { pipeline: pipeline_name } }
-    let(:runner) { described_class.new(**options) }
-
-    context 'for a non-component pipeline' do
-      it 'returns the pipeline definition' do
-        setup_project(:basic)
-
-        expect(runner.pipeline_definition).to be_a(Buildkite::Builder::Definition::Pipeline)
-      end
-    end
-  end
-
   describe '#run' do
     before do
       setup_project(fixture_project)
@@ -133,62 +100,30 @@ RSpec.describe Buildkite::Builder::Runner do
           pipeline_contents = File.read(path)
         end
 
-        runner.run
+        pipeline = runner.run
 
         expect(File.exist?(artifact_path)).to eq(false)
         expect(File.exist?(pipeline_path)).to eq(false)
         expect(artifact_contents).to eq(pipeline_contents)
-        expect(pipeline_contents).to eq(runner.pipeline.to_yaml)
+        expect(pipeline_contents).to eq(pipeline.to_yaml)
       end
     end
   end
 
   describe '#log', skip_logging_stubs: true do
     let(:pipeline_name) { 'dummy' }
-    let(:options) { { pipeline: pipeline_name, verbose: verbose } }
-    let(:verbose) { false }
+    let(:options) { { pipeline: pipeline_name } }
     let(:runner) { described_class.new(**options) }
+    let(:options) { { pipeline: pipeline_name } }
 
-    context 'when verbose' do
-      context 'when option is explicitly set to true' do
-        let(:verbose) { true }
-
-        it 'returns a Logger' do
-          expect(runner.log).to be_a(Logger)
-        end
-
-        it 'logs to stdout' do
-          expect {
-            runner.log.info('foo')
-          }.to output("foo\n").to_stdout
-        end
-      end
-
-      context 'when option is not set explicitly' do
-        let(:options) { { pipeline: pipeline_name } }
-
-        it 'returns a Logger' do
-          expect(runner.log).to be_a(Logger)
-        end
-
-        it 'logs to stdout' do
-          expect {
-            runner.log.info('foo')
-          }.to output("foo\n").to_stdout
-        end
-      end
+    it 'returns a Logger' do
+      expect(runner.log).to be_a(Logger)
     end
 
-    context 'when not verbose' do
-      it 'returns a Logger' do
-        expect(runner.log).to be_a(Logger)
-      end
-
-      it 'does not logs to stdout' do
-        expect {
-          runner.log.info('foo')
-        }.not_to output.to_stdout
-      end
+    it 'logs to stdout' do
+      expect {
+        runner.log.info('foo')
+      }.to output("foo\n").to_stdout
     end
   end
 end

--- a/spec/buildkite/builder/runner_spec.rb
+++ b/spec/buildkite/builder/runner_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 RSpec.describe Buildkite::Builder::Runner do
   describe '#run' do
     before do
@@ -13,65 +11,8 @@ RSpec.describe Buildkite::Builder::Runner do
     let(:options) { { pipeline: pipeline_name } }
     let(:runner) { described_class.new(**options) }
 
-    context 'with an invalid pipeline' do
-      let(:fixture_project) { :invalid_pipeline }
-
-      it 'raises an errors' do
-        expect {
-          runner.run
-        }.to raise_error(/must return a valid definition \(Buildkite::Builder::Definition::Pipeline\)/)
-      end
-    end
-
-    context 'with an invalid step' do
-      let(:fixture_project) { :invalid_step }
-
-      it 'raises an errors' do
-        expect {
-          runner.run
-        }.to raise_error(/must return a valid definition \(Buildkite::Builder::Definition::Template\)/)
-      end
-    end
-
-    it 'loads manifests' do
-      runner.run
-
-      manifests = Buildkite::Builder::Manifest.manifests
-      expect(manifests.size).to eq(1)
-      expect(manifests).to have_key('basic')
-      expect(manifests['basic']).to be_a(Buildkite::Builder::Manifest)
-    end
-
-    it 'loads steps' do
-      pipeline = runner.run
-
-      steps = pipeline.templates
-      expect(steps.size).to eq(1)
-      expect(steps).to have_key('basic')
-      expect(steps['basic']).to be_a(Buildkite::Builder::Definition::Template)
-    end
-
-    it 'loads processors' do
-      pipeline = runner.run
-
-      processors = pipeline.processors
-      expect(processors.size).to eq(2)
-    end
-
     it 'returns the pipeline' do
       expect(runner.run).to be_a(Buildkite::Pipelines::Pipeline)
-    end
-
-    it 'applies the processors' do
-      pipeline = runner.run
-
-      steps = pipeline.steps
-      steps_label_and_commands = steps.map { |step| [step.label, step.command] }
-      expect(steps_label_and_commands).to eq([
-        ['Basic step', ['true']],
-        ['Appended By Processors::PipelineSpecificProcessor', ['echo 1']],
-        ['Appended By Processors::SharedProcessor', ['echo 1']],
-      ])
     end
 
     context 'when uploading' do
@@ -107,23 +48,6 @@ RSpec.describe Buildkite::Builder::Runner do
         expect(artifact_contents).to eq(pipeline_contents)
         expect(pipeline_contents).to eq(pipeline.to_yaml)
       end
-    end
-  end
-
-  describe '#log', skip_logging_stubs: true do
-    let(:pipeline_name) { 'dummy' }
-    let(:options) { { pipeline: pipeline_name } }
-    let(:runner) { described_class.new(**options) }
-    let(:options) { { pipeline: pipeline_name } }
-
-    it 'returns a Logger' do
-      expect(runner.log).to be_a(Logger)
-    end
-
-    it 'logs to stdout' do
-      expect {
-        runner.log.info('foo')
-      }.to output("foo\n").to_stdout
     end
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -6,8 +6,16 @@ require 'pathname'
 module Spec
   module Support
     module Fixtures
-      def fixture_path_for(project, path)
-        Pathname.new('spec/fixtures').join(project.to_s).join(path).expand_path.to_s
+      def fixture_path_for(project)
+        Pathname.new('tmp/fixtures').join(project.to_s).expand_path
+      end
+
+      def fixture_buildkite_path_for(project)
+        fixture_path_for(project).join(Buildkite::Builder::BUILDKITE_DIRECTORY_NAME)
+      end
+
+      def fixture_pipeline_path_for(project, pipeline)
+        fixture_buildkite_path_for(project).join(Buildkite::Builder::Runner::PIPELINES_PATH).join(pipeline.to_s)
       end
 
       def setup_project(project)


### PR DESCRIPTION
This PR extracts out pipeline building logic from `Runner` into another class, `Context`. This separates the logging that naturally comes `Runner#run` from pipeline building--which doesn't care for printouts. Instead of a "pipeline name" getting passed around, we're now passing around a `root` directory for all Loaders.

This also makes pipeline building much more reusable and sets us up for Pipeline merging in the future if we want to go there.