### PR TITLE
Update Dockerfile ruby to 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM ruby:2.7-slim
+FROM ruby:3.0
 ARG version
 
-RUN apt-get update &&                                 \
-    apt-get install -y --no-install-recommends git && \
-    if [ -z ${version} ]; then                        \
+RUN if [ -z ${version} ]; then                        \
       gem install buildkite-builder;                  \
     else                                              \
       gem install buildkite-builder -v ${version};    \

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,11 @@ task :default => :spec
 namespace :docker do
   task :release do
     version = File.read("VERSION").strip
+    puts "🔨 Building docker image for release of Buildkite Builder version #{version}"
+
     system("docker build --tag=gusto/buildkite-builder:#{version} --build-arg version=#{version} .", exception: true)
+
+    puts "📦 Pushing to DockerHub: gusto/buildkite-builder:#{version}"
     system("docker push gusto/buildkite-builder:#{version}", exception: true)
   end
 end


### PR DESCRIPTION
We can't use slim anymore because we use the sorted_set gem. This gem
requires rbtree which can't build without build tools.