### PR TITLE
Add group support

### DIFF
--- a/.buildkite/pipelines/showcase/pipeline.rb
+++ b/.buildkite/pipelines/showcase/pipeline.rb
@@ -1,12 +1,14 @@
 Buildkite::Builder.pipeline do
-  # Load the "rspec" template as a command.
-  # .buildkite/pipelines/showcase/templates/rspec.rb
-  command(:rspec)
+  group do
+    # Load the "rspec" template as a command.
+    # .buildkite/pipelines/showcase/templates/rspec.rb
+    command(:rspec)
 
-  # Load the "rspec" template and modify it on the fly.
-  command(:rspec) do
-    label "RSpec relabeled"
-    command "echo 'do something else'"
+    # Load the "rspec" template and modify it on the fly.
+    command(:rspec) do
+      label "RSpec relabeled"
+      command "echo 'do something else'"
+    end
   end
 
   # Pass arguments into templates.

--- a/lib/buildkite/pipelines.rb
+++ b/lib/buildkite/pipelines.rb
@@ -4,7 +4,9 @@ module Buildkite
   module Pipelines
     autoload :Api, File.expand_path('pipelines/api', __dir__)
     autoload :Attributes, File.expand_path('pipelines/attributes', __dir__)
+    autoload :Builder, File.expand_path('pipelines/builder', __dir__)
     autoload :Command, File.expand_path('pipelines/command', __dir__)
+    autoload :Group, File.expand_path('pipelines/group', __dir__)
     autoload :Helpers, File.expand_path('pipelines/helpers', __dir__)
     autoload :Pipeline, File.expand_path('pipelines/pipeline', __dir__)
     autoload :Plugin, File.expand_path('pipelines/plugin', __dir__)

--- a/lib/buildkite/pipelines/builder.rb
+++ b/lib/buildkite/pipelines/builder.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Buildkite
+  module Pipelines
+    class Builder
+      attr_reader :steps, :templates
+
+      def initialize(definition = nil, &block)
+        @steps = []
+        @plugins = {}
+        @templates = {}
+        @notify = []
+
+        instance_eval(&definition) if definition
+        instance_eval(&block) if block_given?
+      end
+
+      [
+        Steps::Block,
+        Steps::Command,
+        Steps::Input,
+        Steps::Trigger,
+      ].each do |type|
+        define_method(type.to_sym) do |template = nil, **args, &block|
+          add(type, template, **args, &block)
+        end
+      end
+
+      def notify(*args)
+        if args.empty?
+          @notify
+        elsif args.first.is_a?(Hash)
+          @notify.push(args.first.transform_keys(&:to_s))
+        else
+          raise ArgumentError, 'value must be hash'
+        end
+      end
+
+      def skip(template = nil, **args, &block)
+        step = add(Steps::Skip, template, **args, &block)
+        # A skip step has a nil/noop command.
+        step.command(nil)
+        # Always set the skip attribute if it's in a falsey state.
+        step.skip(true) if !step.get(:skip) || step.skip.empty?
+        step
+      end
+
+      def wait(attributes = {}, &block)
+        step = add(Steps::Wait, &block)
+        step.wait(nil)
+        attributes.each do |key, value|
+          step.set(key, value)
+        end
+        step
+      end
+
+      def template(name, &definition)
+        name = name.to_s
+
+        if templates.key?(name)
+          raise ArgumentError, "Template already defined: #{name}"
+        elsif !block_given?
+          raise ArgumentError, 'Template definition block must be given'
+        end
+
+        @templates[name.to_s] = definition
+      end
+
+      private
+
+      def add(step_class, template = nil, **args, &block)
+        steps.push(step_class.new(self, find_template(template), **args, &block)).last
+      end
+
+      def find_template(name)
+        return unless name
+
+        templates[name.to_s] || begin
+          raise ArgumentError, "Template not defined: #{name}"
+        end
+      end
+    end
+  end
+end

--- a/lib/buildkite/pipelines/group.rb
+++ b/lib/buildkite/pipelines/group.rb
@@ -1,0 +1,17 @@
+module Buildkite
+  module Pipelines
+    class Group < Builder
+      attr_reader :name
+
+      def initialize(name, &block)
+        @name = name
+
+        super(nil, &block)
+      end
+
+      def to_h
+        Helpers.sanitize(group: name, steps: steps.map(&:to_h))
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Abstract some pipeline methods to `Pipelines::Builder` to be able to use in `Pipelines::Group`
- Makes sure group shares same templates as pipeline instance