### PR TITLE
Remove noop helper method

### DIFF
--- a/.buildkite/pipelines/showcase/pipeline.rb
+++ b/.buildkite/pipelines/showcase/pipeline.rb
@@ -18,7 +18,7 @@ Buildkite::Builder.pipeline do
   if true == false
     command do
       label "This won't run"
-      command :noop
+      command 'true'
     end
   end
 
@@ -28,7 +28,7 @@ Buildkite::Builder.pipeline do
   # Add a skipped step. You can see this step when you click the "eye" icon on
   # the Buildkite web UI.
   command do
-    command :noop
+    command 'true'
     label "Skipped Step"
 
     # Conditionally skip a step.

--- a/.buildkite/pipelines/showcase/templates/generic.rb
+++ b/.buildkite/pipelines/showcase/templates/generic.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do |context|
   label "Step w/ Arg: #{context[:foo]}"
-  command :noop
+  command 'true'
 end

--- a/.buildkite/pipelines/showcase/templates/rspec.rb
+++ b/.buildkite/pipelines/showcase/templates/rspec.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do
   label "Run Specs", emoji: :rspec
-  command :noop
+  command 'true'
 end

--- a/lib/buildkite/pipelines/helpers/command.rb
+++ b/lib/buildkite/pipelines/helpers/command.rb
@@ -8,11 +8,7 @@ module Buildkite
           return super if values.empty?
 
           values.flatten.each do |value|
-            if value == :noop
-              super('true')
-            else
-              super(value)
-            end
+            super(value)
           end
         end
       end

--- a/spec/buildkite/pipelines/helpers/command_spec.rb
+++ b/spec/buildkite/pipelines/helpers/command_spec.rb
@@ -11,21 +11,11 @@ RSpec.describe Buildkite::Pipelines::Helpers::Command do
 
   let(:step) { step_klass.new }
 
-  describe '#command' do
-    context 'when value is noop' do
-      it 'sets true' do
-        step.command(:noop)
+  describe "#command" do
+    it "sets what's passed in" do
+      step.command(:foo)
 
-        expect(step.get(:command)).to eq('true')
-      end
-    end
-
-    context 'when other value' do
-      it "sets what's passed in" do
-        step.command(:foo)
-
-        expect(step.get(:command)).to eq(:foo)
-      end
+      expect(step.get(:command)).to eq(:foo)
     end
   end
 end

--- a/spec/fixtures/basic/.buildkite/pipelines/dummy/templates/basic.rb
+++ b/spec/fixtures/basic/.buildkite/pipelines/dummy/templates/basic.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do
   label 'Basic step'
-  command :noop
+  command 'true'
 end

--- a/spec/fixtures/basic_with_processors/.buildkite/pipelines/dummy/templates/basic.rb
+++ b/spec/fixtures/basic_with_processors/.buildkite/pipelines/dummy/templates/basic.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do
   label 'Basic step'
-  command :noop
+  command 'true'
 end

--- a/spec/fixtures/basic_with_shared_and_pipeline_processors/.buildkite/pipelines/dummy/templates/basic.rb
+++ b/spec/fixtures/basic_with_shared_and_pipeline_processors/.buildkite/pipelines/dummy/templates/basic.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do
   label 'Basic step'
-  command :noop
+  command 'true'
 end

--- a/spec/fixtures/component/.buildkite/pipelines/dummy/templates/component.rb
+++ b/spec/fixtures/component/.buildkite/pipelines/dummy/templates/component.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do
   label 'Basic step'
-  command :noop
+  command 'true'
 end

--- a/spec/fixtures/component_opted_out/.buildkite/pipelines/dummy/templates/component.rb
+++ b/spec/fixtures/component_opted_out/.buildkite/pipelines/dummy/templates/component.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do
   label 'Basic step'
-  command :noop
+  command 'true'
 end

--- a/spec/fixtures/simple/.buildkite/pipeline.rb
+++ b/spec/fixtures/simple/.buildkite/pipeline.rb
@@ -1,6 +1,6 @@
 Buildkite::Builder.pipeline do
   command do
     label 'Simple step'
-    command :noop
+    command 'true'
   end
 end

--- a/spec/fixtures/single_pipeline/.buildkite/templates/basic.rb
+++ b/spec/fixtures/single_pipeline/.buildkite/templates/basic.rb
@@ -1,4 +1,4 @@
 Buildkite::Builder.template do
   label 'Basic step'
-  command :noop
+  command 'true'
 end


### PR DESCRIPTION
This was a little helper method to for `command 'true'`..but it seems random now. Let's leave this up to the BKB user to add dummy commands.