### PR TITLE
Update required ruby version to reflect reality

### DIFF
--- a/buildkite-builder.gemspec
+++ b/buildkite-builder.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.homepage      = "https://github.com/Gusto/buildkite-builder"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/Gusto/buildkite-builder"


### PR DESCRIPTION
It hasn't worked on 2.6, or even 2.7 for awhile now. fixes https://github.com/Gusto/buildkite-builder/issues/69 ("fixes") by explicitly supporting 2.6