### PR TITLE
Remove private attr_reader for extensions

### DIFF
--- a/lib/buildkite/builder/pipeline.rb
+++ b/lib/buildkite/builder/pipeline.rb
@@ -81,8 +81,6 @@ module Buildkite
 
       private
 
-      attr_reader :extensions
-
       def upload_artifacts
         return if artifacts.empty?
 


### PR DESCRIPTION
Didn't notice we have it as private attribute, which overrides https://github.com/Gusto/buildkite-builder/pull/76