### PR TITLE
No need to return self in initialize

### DIFF
--- a/lib/buildkite/builder/extensions/sub_pipelines.rb
+++ b/lib/buildkite/builder/extensions/sub_pipelines.rb
@@ -41,7 +41,6 @@ module Buildkite
             @dsl.instance_variable_set(:@context, self)
 
             instance_eval(&block) if block_given?
-            self
           end
 
           def to_h

--- a/lib/buildkite/builder/group.rb
+++ b/lib/buildkite/builder/group.rb
@@ -28,7 +28,6 @@ module Buildkite
         @dsl.instance_variable_set(:@context, self)
 
         instance_eval(&block) if block_given?
-        self
       end
 
       def to_h


### PR DESCRIPTION
Seems like this was introduced while modifying the concept in feature implementation.