### PR TITLE
Remove warning of method redefined

### DIFF
--- a/lib/buildkite/builder/extension.rb
+++ b/lib/buildkite/builder/extension.rb
@@ -4,8 +4,6 @@ module Buildkite
   module Builder
     class Extension
       class << self
-        attr_reader :dsl
-
         def dsl(&block)
           @dsl = Module.new(&block) if block_given?
           @dsl


### PR DESCRIPTION
This reader isn't used to anything and having it here generates a warning.

```
buildkite-builder-4.2.4/lib/buildkite/builder/extension.rb:9: warning: method redefined; discarding old dsl
```