### PR TITLE
Allow overriding path for preview command

### DIFF
--- a/lib/buildkite/builder/commands/preview.rb
+++ b/lib/buildkite/builder/commands/preview.rb
@@ -11,6 +11,17 @@ module Buildkite
         def run
           puts Pipeline.new(pipeline_path).to_yaml
         end
+
+        def pipeline_path
+          pipeline_path_override || super
+        end
+
+        def pipeline_path_override
+          if ENV['BUILDKITE_BUILDER_PIPELINE_PATH']
+            path = Pathname.new(ENV['BUILDKITE_BUILDER_PIPELINE_PATH'])
+            path.absolute? ? path : Builder.root.join(path)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
I've noticed in #27 that only the `run` command supports overriding the pipeline path.

The motivation is that we use `preview` to compare branches from a current main checkout to generate a diff of the pipeline. It only worked before when upstream was not using bkb so I didn't notice until rails/buildkite-config#73 was merged.

Commands:

```
$ git clone https://github.com/rails/buildkite-config
$ git clone --depth=1 https://github.com/rails/rails tmp/rails
$ git clone --depth=1 https://github.com/rails/buildkite-config tmp/buildkite-config
$ BUILDKITE_BUILDER_PIPELINE_PATH=$PWD/tmp/buildkite-config/pipelines/rails-ci bundle exec buildkite-builder preview rails-ci
```

If you change something in the main pipeline, like remove actiontext from `./pipelines/rails-ci/pipeline.rb` you will still see it when running the last command because it's still previewing the pipeline in `Dir.pwd`.

Also, I _think_ absolute path is not required but seems to work without it.

Anyways this code probably is not factored correctly and needs tests, but raising it as a PR to get feedback / pointers as opposed to commenting on a 3 year old PR :joy:

FWIW, we would have to do something like this to use this feature once it's available:

```diff
diff --git a/lib/buildkite/config/diff.rb b/lib/buildkite/config/diff.rb
index abfb682..b2e1179 100644
--- a/lib/buildkite/config/diff.rb
+++ b/lib/buildkite/config/diff.rb
@@ -11,6 +11,12 @@ module Buildkite::Config
     end

     def self.generated_pipeline(repo, nightly: false)
+      before_env_gemfile = ENV["BUNDLE_GEMFILE"]
+      before_env_builder_path = ENV["BUILDKITE_BUILDER_PIPELINE_PATH"]
+
+      ENV["BUNDLE_GEMFILE"] = "#{repo}/Gemfile"
+      ENV["BUILDKITE_BUILDER_PIPELINE_PATH"] = "#{repo}/pipelines"
+
       command = ["ruby", "#{repo}/pipeline-generate"]

       command.push("--nightly") if nightly
@@ -29,6 +35,9 @@ module Buildkite::Config
       end

       output
+    ensure
+      ENV["BUNDLE_GEMFILE"] = before_env_gemfile
+      ENV["BUILDKITE_BUILDER_PIPELINE_PATH"] = before_env_builder_path
     end
   end
 end
diff --git a/pipeline-generate b/pipeline-generate
index a7dab35..d617de0 100755
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -19,6 +19,10 @@ if %w[rails-ci rails-ci-nightly rails-sandbox zzak/rails rails rails-nightly].in
   env["BUNDLE_GEMFILE"] = ".buildkite/Gemfile"
 end

+if ENV.key?("BUILDKITE_BUILDER_PIPELINE_PATH")
+  env["BUILDKITE_BUILDER_PIPELINE_PATH"] = ENV["BUILDKITE_BUILDER_PIPELINE_PATH"]
+end
+
 run "bundle install", env

 pipeline = run "bundle exec buildkite-builder preview rails-ci#{ "-nightly" if nightly }", env, true
```