### PR TITLE
Fix access to buildkite-agent owned git repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN if [ -z ${version} ]; then                        \
       gem install buildkite-builder -v ${version};    \
     fi
 
+RUN git config --global --add safe.directory /workdir
+
 CMD buildkite-builder run


### PR DESCRIPTION
Fixes https://buildkite.com/gusto/payroll-building-blocks/builds/22494#018f874e-1aa8-4454-9b08-b849c6b59645/217-219, which was likely introduced in https://github.com/Gusto/buildkite-builder/pull/113 with the git upgrade from `2.30.2` to `2.39.2`.

The container is running at `root` (id: 1), but the repositories are owned by `buildkite-agent` (id: 9999), which is tripping git. I believe `/workdir` is a [Buildkite Docker plugin concept](https://github.com/search?q=repo%3Abuildkite-plugins%2Fdocker-buildkite-plugin%20workdir&type=code).