### PR TITLE
Update Buildkite pipelines to use Ruby 3.3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,6 @@ steps:
           limit: 2
     plugins:
       - docker#v5.7.0:
-          image: "ruby:3.0"
+          image: "ruby:3.3"
           propagate-environment: true
           mount-buildkite-agent: true

--- a/.buildkite/pipelines/buildkite-builder/pipeline.rb
+++ b/.buildkite/pipelines/buildkite-builder/pipeline.rb
@@ -8,7 +8,7 @@ Buildkite::Builder.pipeline do
       "bundle",
       "rake"
     plugin :docker,
-      image: "ruby:3.0"
+      image: "ruby:3.3"
   end
 
   trigger do


### PR DESCRIPTION
The Docker image version was bumped in #113.