### PR TITLE
Public send keys for wait step

### DIFF
--- a/lib/buildkite/builder/extensions/steps.rb
+++ b/lib/buildkite/builder/extensions/steps.rb
@@ -60,7 +60,7 @@ module Buildkite
             context.extensions.find(Steps).build_step(Pipelines::Steps::Wait, nil, &block).tap do |step|
               step.wait(nil)
               attributes.each do |key, value|
-                step.set(key, value)
+                step.public_send(key, value)
               end
             end
           end


### PR DESCRIPTION
This changes the setting of `wait` step attributes to using `public_send` and the setter methods instead of using `set`. This is more accurate since there could be transformations being done at the attribute helper leave that you'd only get when you call the attribute-named method.