### PR TITLE
Add DSL to register multiple plugins

### DIFF
--- a/.buildkite/pipelines/showcase/pipeline.rb
+++ b/.buildkite/pipelines/showcase/pipeline.rb
@@ -23,6 +23,10 @@ Buildkite::Builder.pipeline do
   # Register a plugin for steps to use.
   plugin :skip_checkout, 'thedyrt/skip-checkout#v0.1.1'
 
+  plugins [
+    [:pr_commenter, 'pr-commenter#v0.0.1', { message: "LGTM!" }]
+  ]
+
   command do
     label "Step w/ Plugin"
     key :step_with_plugin

--- a/lib/buildkite/builder/extensions/plugins.rb
+++ b/lib/buildkite/builder/extensions/plugins.rb
@@ -8,6 +8,13 @@ module Buildkite
           def plugin(name, uri, default_attributes = {})
             context.extensions.find(Buildkite::Builder::Extensions::Plugins).manager.add(name, uri, default_attributes)
           end
+
+          def plugins(plugins)
+            plugins.each do |plugin|
+              name, uri, default_attributes = plugin
+              context.extensions.find(Buildkite::Builder::Extensions::Plugins).manager.add(name, uri, default_attributes || {})
+            end
+          end
         end
 
         def prepare

--- a/spec/buildkite/builder/extensions/plugins_spec.rb
+++ b/spec/buildkite/builder/extensions/plugins_spec.rb
@@ -11,11 +11,32 @@ RSpec.describe Buildkite::Builder::Extensions::Plugins do
   let(:extension) { pipeline.extensions.find(described_class) }
 
   describe 'dsl methods' do
+    it 'raises an error if plugin is already defined' do
+      pipeline.dsl.plugins([
+        [:foo, 'foo#v1.2.3', { tty: true }],
+        [:bar, 'bar#v1.2']
+      ])
+
+      expect { pipeline.dsl.plugin(:bar, 'bar#v2.0') }.to raise_error(ArgumentError, "Plugin already defined: bar")
+    end
+
     describe '#plugin' do
       it 'adds the extension to the manager' do
         pipeline.dsl.plugin(:foo, 'foo#v1.2.3')
 
         expect(extension.manager.build(:foo)).to eq( {'foo#v1.2.3' => {} })
+      end
+    end
+
+    describe '#plugins' do
+      it 'adds the extensions to the manager' do
+        pipeline.dsl.plugins([
+          [:foo, 'foo#v1.2.3', { tty: true }],
+          [:bar, 'bar#v1.2']
+        ])
+
+        expect(extension.manager.build(:foo)).to eq( {'foo#v1.2.3' => { tty: true } })
+        expect(extension.manager.build(:bar)).to eq( {'bar#v1.2' => {} })
       end
     end
   end


### PR DESCRIPTION
This PR adds a simplified way to register multiple Buildkite plugins at once in your pipeline configuration.

You can now register multiple plugins simultaneously:
```ruby
plugins [
  [:docker, "docker#v5.3.0", { image: "ruby:3.2" }],
  [:ecr, "ecr#v2.7.0", { account_ids: "123456789" }],
  [:cache, "cache#v0.2.1", { paths: ["vendor/bundle"] }]
]

plugins Base::PLUGINS
```