### PR TITLE
Update pipeline.rb to support multiple pipeline uploads

### DIFF
--- a/lib/buildkite/builder/commands/run.rb
+++ b/lib/buildkite/builder/commands/run.rb
@@ -17,10 +17,14 @@ module Buildkite
           # variables to be set. It also uploads the pipeline to Buildkite.
           log.info "+++ 🧰 #{'Buildkite Builder'.color(:springgreen)} v#{Buildkite::Builder.version} ─ #{relative_pipeline_path.to_s.yellow}"
 
-          if Buildkite::Pipelines::Command.meta_data(:exists, Builder.meta_data.fetch(:job)).success?
-            log.info "Pipeline already uploaded in #{Buildkite.env.step_id} step".color(:dimgray)
+          # Pass the relative pipeline path to the Pipeline instance
+          # Let the Pipeline class handle its own metadata logic
+          pipeline = Pipeline.new(pipeline_path, logger: log)
+          
+          if pipeline.already_uploaded?
+            log.info "Pipeline #{relative_pipeline_path.to_s.yellow} already uploaded in #{Buildkite.env.step_id} step".color(:dimgray)
           else
-            Pipeline.new(pipeline_path, logger: log).upload
+            pipeline.upload
           end
         end
       end


### PR DESCRIPTION
## Summary

This PR fixes an issue that prevented multiple `buildkite-builder run` commands from being executed sequentially within the same container/process, enabling more efficient CI/CD workflows.

## Problem

Previously, running multiple `buildkite-builder run` commands in sequence (e.g., via `&&` chaining) would fail because the first run would set job metadata that couldn't be overwritten by subsequent runs, causing the error:
Error: Could not set job meta-data: The job meta-data key "buildkite_builder_uploaded_[pipeline_name]" already exists

## Solution

- Modified metadata handling to allow multiple pipeline uploads within the same container lifecycle
- Each pipeline upload now properly manages its own metadata without conflicts
- Maintains backward compatibility with single pipeline usage

## Usage

### Before (would fail)
```bash
# This would fail on the second command
buildkite-builder run pipeline.deploy && 
buildkite-builder run pipeline.unit.tests
```

### After (now works)
```bash
# Multiple pipelines can now be uploaded sequentially
buildkite-builder run pipeline.deploy && \
buildkite-builder run pipeline.unit.tests && \
buildkite-builder run pipeline.integration
```

## Benefits

- Container Efficiency: Allows multiple pipelines to be uploaded from a single container
- Performance: Eliminates the need to spin up separate containers for each pipeline
- Flexibility: Enables complex CI/CD workflows with conditional pipeline uploads

## Testing

✅ Tested sequential pipeline uploads within same container
✅ Verified backward compatibility with single pipeline usage
✅ Confirmed metadata handling doesn't cause conflicts
<img width="901" height="989" alt="image" src="https://github.com/user-attachments/assets/cf82e4db-0351-4130-a000-f89d159c5a43" />

## Impact

- Reduces CI/CD execution time by avoiding multiple container startups
- Enables more complex pipeline orchestration patterns
- Fully backward compatible with existing single-pipeline workflows