### PR TITLE
Add dependency on `benchmark`

### DIFF
--- a/buildkite-builder.gemspec
+++ b/buildkite-builder.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rainbow", ">= 3"
+  spec.add_dependency "benchmark"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "debug"


### PR DESCRIPTION
It's no longer a default gem on Ruby 4.0.