### PR TITLE
feat(validation): add pipeline schema validation :sparkles:

### DIFF
--- a/buildkite-builder.gemspec
+++ b/buildkite-builder.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir["exe/*"].map { |exe| File.basename(exe) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "json_schemer", "~> 2.0"
   spec.add_dependency "rainbow", ">= 3"
   spec.add_dependency "benchmark"
   spec.add_dependency "logger"

--- a/buildkite-builder.gemspec
+++ b/buildkite-builder.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "ostruct"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov_json_formatter"
 end

--- a/lib/buildkite/builder.rb
+++ b/lib/buildkite/builder.rb
@@ -23,6 +23,7 @@ module Buildkite
     autoload :TemplateManager, File.expand_path('builder/template_manager', __dir__)
     autoload :PluginManager, File.expand_path('builder/plugin_manager', __dir__)
     autoload :Validator, File.expand_path('builder/validator', __dir__)
+    autoload :Matchers, File.expand_path('builder/matchers', __dir__)
 
     BUILDKITE_DIRECTORY_NAME = Pathname.new('.buildkite').freeze
 

--- a/lib/buildkite/builder.rb
+++ b/lib/buildkite/builder.rb
@@ -22,6 +22,7 @@ module Buildkite
     autoload :PipelineCollection, File.expand_path('builder/pipeline_collection', __dir__)
     autoload :TemplateManager, File.expand_path('builder/template_manager', __dir__)
     autoload :PluginManager, File.expand_path('builder/plugin_manager', __dir__)
+    autoload :Validator, File.expand_path('builder/validator', __dir__)
 
     BUILDKITE_DIRECTORY_NAME = Pathname.new('.buildkite').freeze
 

--- a/lib/buildkite/builder/commands.rb
+++ b/lib/buildkite/builder/commands.rb
@@ -6,7 +6,8 @@ module Buildkite
       using Rainbow
       COMMANDS = {
         'preview' => :Preview,
-        'run' => :Run
+        'run' => :Run,
+        'validate' => :Validate
       }.freeze
 
       autoload :Abstract, File.expand_path('commands/abstract', __dir__)

--- a/lib/buildkite/builder/commands/abstract.rb
+++ b/lib/buildkite/builder/commands/abstract.rb
@@ -80,10 +80,7 @@ module Buildkite
           errors = Validator.new.validate_all(pipeline.to_h, pipeline.steps)
           return if errors.empty?
 
-          errors.each do |error|
-            location = error.source_location ? "#{error.source_location.file}:#{error.source_location.line_number} " : ''
-            $stderr.puts "#{location}#{error.pointer}: #{error.message}"
-          end
+          errors.each { |error| $stderr.puts error.to_s }
 
           if options[:warn]
             $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."

--- a/lib/buildkite/builder/commands/abstract.rb
+++ b/lib/buildkite/builder/commands/abstract.rb
@@ -6,6 +6,8 @@ module Buildkite
   module Builder
     module Commands
       class Abstract
+        using Rainbow
+
         PIPELINES_DIRECTORY = 'pipelines'
         POSSIBLE_PIPELINE_PATHS = [
           File.join('.buildkite', Pipeline::PIPELINE_DEFINITION_FILE),
@@ -85,10 +87,10 @@ module Buildkite
           errors.each { |error| $stderr.puts error.to_s }
 
           if options[:strict]
-            abort "Pipeline validation failed with #{errors.size} error(s)."
+            abort "Pipeline validation failed with #{errors.size.to_s.yellow} error(s)."
           else
-            $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
-            $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release."
+            $stderr.puts "Pipeline validation produced #{errors.size.to_s.yellow} warning(s)."
+            $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release.".color(:dimgray)
           end
         end
 

--- a/lib/buildkite/builder/commands/abstract.rb
+++ b/lib/buildkite/builder/commands/abstract.rb
@@ -69,23 +69,36 @@ module Buildkite
             options[:no_validate] = true
           end
 
-          opts.on('--warn', 'Downgrade validation errors to warnings instead of failing') do
-            options[:warn] = true
+          opts.on('--strict', 'Fail on validation errors (will be the default in the next major release)') do
+            options[:strict] = true
           end
         end
 
         def validate_pipeline(pipeline)
           return if options[:no_validate]
 
+          enforce_strict_default_migration!
+
           errors = Validator.new.validate_all(pipeline.to_h, pipeline.steps)
           return if errors.empty?
 
           errors.each { |error| $stderr.puts error.to_s }
 
-          if options[:warn]
-            $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
-          else
+          if options[:strict]
             abort "Pipeline validation failed with #{errors.size} error(s)."
+          else
+            $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
+            $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release."
+          end
+        end
+
+        # Raise at development time when the major version increments, so we
+        # remember to flip the default from warn to strict.
+        def enforce_strict_default_migration!
+          major = Buildkite::Builder.version.split('.').first.to_i
+          if major >= 5
+            raise "buildkite-builder v#{Buildkite::Builder.version}: validation now defaults to warn mode. " \
+                  "Flip the default to strict and remove this guard. See #{__FILE__}:#{__LINE__}."
           end
         end
 

--- a/lib/buildkite/builder/commands/abstract.rb
+++ b/lib/buildkite/builder/commands/abstract.rb
@@ -77,7 +77,7 @@ module Buildkite
         def validate_pipeline(pipeline)
           return if options[:no_validate]
 
-          errors = Validator.new.validate_all(pipeline.to_h, pipeline.data.steps)
+          errors = Validator.new.validate_all(pipeline.to_h, pipeline.steps)
           return if errors.empty?
 
           errors.each do |error|

--- a/lib/buildkite/builder/commands/abstract.rb
+++ b/lib/buildkite/builder/commands/abstract.rb
@@ -6,6 +6,7 @@ module Buildkite
   module Builder
     module Commands
       class Abstract
+        include LoggingUtils
         using Rainbow
 
         PIPELINES_DIRECTORY = 'pipelines'
@@ -82,15 +83,28 @@ module Buildkite
           enforce_strict_default_migration!
 
           errors = Validator.new.validate_all(pipeline.to_h, pipeline.steps)
-          return if errors.empty?
 
-          errors.each { |error| $stderr.puts error.to_s }
+          log_validation_results(errors)
+        end
+
+        def log_validation_results(errors)
+          prefix = '│'.color(:springgreen)
+          closer = '└──'.color(:springgreen)
+
+          $stderr.puts "\n" + 'Validating pipeline'.color(:dimgray)
+
+          if errors.empty?
+            $stderr.puts "#{closer} #{'Pipeline is valid.'.color(:springgreen)}"
+            return
+          end
+
+          errors.each { |error| $stderr.puts "#{prefix} #{error}" }
 
           if options[:strict]
-            abort "Pipeline validation failed with #{errors.size.to_s.yellow} error(s)."
+            $stderr.puts "#{closer} " + "Pipeline validation failed with #{pluralize(errors.size, 'error')}.".color(:dimgray)
+            abort
           else
-            $stderr.puts "Pipeline validation produced #{errors.size.to_s.yellow} warning(s)."
-            $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release.".color(:dimgray)
+            $stderr.puts "#{closer} " + "#{pluralize(errors.size, 'warning')}. Pass --strict to fail on validation errors.".color(:dimgray)
           end
         end
 

--- a/lib/buildkite/builder/commands/abstract.rb
+++ b/lib/buildkite/builder/commands/abstract.rb
@@ -65,8 +65,31 @@ module Buildkite
         end
 
         def parse_options(opts)
-          # noop
-          # Subclasses should override to parse options.
+          opts.on('--no-validate', 'Skip schema validation') do
+            options[:no_validate] = true
+          end
+
+          opts.on('--warn', 'Downgrade validation errors to warnings instead of failing') do
+            options[:warn] = true
+          end
+        end
+
+        def validate_pipeline(pipeline)
+          return if options[:no_validate]
+
+          errors = Validator.new.validate_all(pipeline.to_h, pipeline.data.steps)
+          return if errors.empty?
+
+          errors.each do |error|
+            location = error.source_location ? "#{error.source_location.file}:#{error.source_location.line_number} " : ''
+            $stderr.puts "#{location}#{error.pointer}: #{error.message}"
+          end
+
+          if options[:warn]
+            $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
+          else
+            abort "Pipeline validation failed with #{errors.size} error(s)."
+          end
         end
 
         def log

--- a/lib/buildkite/builder/commands/preview.rb
+++ b/lib/buildkite/builder/commands/preview.rb
@@ -9,7 +9,9 @@ module Buildkite
         self.description = 'Outputs the pipeline YAML.'
 
         def run
-          puts Pipeline.new(pipeline_path).to_yaml
+          pipeline = Pipeline.new(pipeline_path)
+          validate_pipeline(pipeline)
+          puts pipeline.to_yaml
         end
       end
     end

--- a/lib/buildkite/builder/commands/run.rb
+++ b/lib/buildkite/builder/commands/run.rb
@@ -20,7 +20,9 @@ module Buildkite
           if Buildkite::Pipelines::Command.meta_data(:exists, Builder.meta_data.fetch(:job)).success?
             log.info "Pipeline already uploaded in #{Buildkite.env.step_id} step".color(:dimgray)
           else
-            Pipeline.new(pipeline_path, logger: log).upload
+            pipeline = Pipeline.new(pipeline_path, logger: log)
+            validate_pipeline(pipeline)
+            pipeline.upload
           end
         end
       end

--- a/lib/buildkite/builder/commands/validate.rb
+++ b/lib/buildkite/builder/commands/validate.rb
@@ -16,19 +16,18 @@ module Buildkite
 
         def run
           pipeline = Pipeline.new(pipeline_path)
-          validator = Validator.new(**validator_options)
-          errors = validator.validate(pipeline.to_h)
+          validator = options[:schema] ? Validator.new(schema_path: options[:schema]) : Validator.new
+          errors = validator.validate_all(pipeline.to_h, pipeline.steps)
 
           if errors.empty?
             puts 'Pipeline is valid.'
           else
-            errors.each { |e| $stderr.puts "#{e.pointer}: #{e.message}" }
+            errors.each do |error|
+              location = error.source_location ? "#{error.source_location.file}:#{error.source_location.line_number} " : ''
+              $stderr.puts "#{location}#{error.pointer}: #{error.message}"
+            end
             abort "Pipeline validation failed with #{errors.size} error(s)."
           end
-        end
-
-        def validator_options
-          options[:schema] ? { schema_path: options[:schema] } : {}
         end
       end
     end

--- a/lib/buildkite/builder/commands/validate.rb
+++ b/lib/buildkite/builder/commands/validate.rb
@@ -22,10 +22,7 @@ module Buildkite
           if errors.empty?
             puts 'Pipeline is valid.'
           else
-            errors.each do |error|
-              location = error.source_location ? "#{error.source_location.file}:#{error.source_location.line_number} " : ''
-              $stderr.puts "#{location}#{error.pointer}: #{error.message}"
-            end
+            errors.each { |error| $stderr.puts error.to_s }
             abort "Pipeline validation failed with #{errors.size} error(s)."
           end
         end

--- a/lib/buildkite/builder/commands/validate.rb
+++ b/lib/buildkite/builder/commands/validate.rb
@@ -9,6 +9,7 @@ module Buildkite
         private
 
         def parse_options(opts)
+          super
           opts.on('--schema PATH', 'Path to a custom JSON schema file') do |path|
             options[:schema] = path
           end
@@ -23,7 +24,11 @@ module Buildkite
             puts 'Pipeline is valid.'
           else
             errors.each { |error| $stderr.puts error.to_s }
-            abort "Pipeline validation failed with #{errors.size} error(s)."
+            if options[:warn]
+              $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
+            else
+              abort "Pipeline validation failed with #{errors.size} error(s)."
+            end
           end
         end
       end

--- a/lib/buildkite/builder/commands/validate.rb
+++ b/lib/buildkite/builder/commands/validate.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Buildkite
+  module Builder
+    module Commands
+      class Validate < Abstract
+        self.description = 'Validates the pipeline against the Buildkite schema.'
+
+        private
+
+        def parse_options(opts)
+          opts.on('--schema PATH', 'Path to a custom JSON schema file') do |path|
+            options[:schema] = path
+          end
+        end
+
+        def run
+          pipeline = Pipeline.new(pipeline_path)
+          validator = Validator.new(**validator_options)
+          errors = validator.validate(pipeline.to_h)
+
+          if errors.empty?
+            puts 'Pipeline is valid.'
+          else
+            errors.each { |e| $stderr.puts "#{e.pointer}: #{e.message}" }
+            abort "Pipeline validation failed with #{errors.size} error(s)."
+          end
+        end
+
+        def validator_options
+          options[:schema] ? { schema_path: options[:schema] } : {}
+        end
+      end
+    end
+  end
+end

--- a/lib/buildkite/builder/commands/validate.rb
+++ b/lib/buildkite/builder/commands/validate.rb
@@ -24,10 +24,11 @@ module Buildkite
             puts 'Pipeline is valid.'
           else
             errors.each { |error| $stderr.puts error.to_s }
-            if options[:warn]
-              $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
-            else
+            if options[:strict]
               abort "Pipeline validation failed with #{errors.size} error(s)."
+            else
+              $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
+              $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release."
             end
           end
         end

--- a/lib/buildkite/builder/commands/validate.rb
+++ b/lib/buildkite/builder/commands/validate.rb
@@ -4,6 +4,8 @@ module Buildkite
   module Builder
     module Commands
       class Validate < Abstract
+        using Rainbow
+
         self.description = 'Validates the pipeline against the Buildkite schema.'
 
         private
@@ -21,14 +23,14 @@ module Buildkite
           errors = validator.validate_all(pipeline.to_h, pipeline.steps)
 
           if errors.empty?
-            puts 'Pipeline is valid.'
+            puts "#{'Pipeline is valid.'.color(:springgreen)}"
           else
             errors.each { |error| $stderr.puts error.to_s }
             if options[:strict]
-              abort "Pipeline validation failed with #{errors.size} error(s)."
+              abort "Pipeline validation failed with #{errors.size.to_s.yellow} error(s)."
             else
-              $stderr.puts "Pipeline validation produced #{errors.size} warning(s)."
-              $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release."
+              $stderr.puts "Pipeline validation produced #{errors.size.to_s.yellow} warning(s)."
+              $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release.".color(:dimgray)
             end
           end
         end

--- a/lib/buildkite/builder/commands/validate.rb
+++ b/lib/buildkite/builder/commands/validate.rb
@@ -18,21 +18,13 @@ module Buildkite
         end
 
         def run
+          enforce_strict_default_migration!
+
           pipeline = Pipeline.new(pipeline_path)
           validator = options[:schema] ? Validator.new(schema_path: options[:schema]) : Validator.new
           errors = validator.validate_all(pipeline.to_h, pipeline.steps)
 
-          if errors.empty?
-            puts "#{'Pipeline is valid.'.color(:springgreen)}"
-          else
-            errors.each { |error| $stderr.puts error.to_s }
-            if options[:strict]
-              abort "Pipeline validation failed with #{errors.size.to_s.yellow} error(s)."
-            else
-              $stderr.puts "Pipeline validation produced #{errors.size.to_s.yellow} warning(s)."
-              $stderr.puts "Pass --strict to fail on validation errors. This will become the default in the next major release.".color(:dimgray)
-            end
-          end
+          log_validation_results(errors)
         end
       end
     end

--- a/lib/buildkite/builder/matchers.rb
+++ b/lib/buildkite/builder/matchers.rb
@@ -24,11 +24,8 @@ module Buildkite
         end
 
         failure_message do |_pipeline_hash|
-          lines = @errors.map do |e|
-            location = e.source_location ? " (#{e.source_location.file}:#{e.source_location.line_number})" : ''
-            "  #{e.pointer}: #{e.message}#{location}"
-          end
-          "expected pipeline to be valid, but got #{@errors.size} error(s):\n#{lines.join("\n")}"
+          "expected pipeline to be valid, but got #{@errors.size} error(s):\n" +
+            @errors.map { |e| "  #{e}" }.join("\n")
         end
       end
     end

--- a/lib/buildkite/builder/matchers.rb
+++ b/lib/buildkite/builder/matchers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+module Buildkite
+  module Builder
+    module Matchers
+      extend RSpec::Matchers::DSL
+
+      # RSpec matcher that validates a pipeline hash against the Buildkite schema.
+      #
+      # Usage:
+      #   expect(pipeline.to_h).to be_valid_pipeline
+      #   expect(pipeline.to_h).to be_valid_pipeline.with_schema('/path/to/schema.json')
+      matcher :be_valid_pipeline do
+        chain :with_schema do |path|
+          @schema_path = path
+        end
+
+        match do |pipeline_hash|
+          validator_options = @schema_path ? { schema_path: @schema_path } : {}
+          @errors = Validator.new(**validator_options).validate(pipeline_hash)
+          @errors.empty?
+        end
+
+        failure_message do |_pipeline_hash|
+          lines = @errors.map do |e|
+            location = e.source_location ? " (#{e.source_location.file}:#{e.source_location.line_number})" : ''
+            "  #{e.pointer}: #{e.message}#{location}"
+          end
+          "expected pipeline to be valid, but got #{@errors.size} error(s):\n#{lines.join("\n")}"
+        end
+      end
+    end
+  end
+end

--- a/lib/buildkite/builder/pipeline.rb
+++ b/lib/buildkite/builder/pipeline.rb
@@ -15,6 +15,7 @@ module Buildkite
       PIPELINE_DEFINITION_FILE = Pathname.new('pipeline.rb').freeze
 
       def_delegator :@extensions, :use
+      def_delegator :@data, :steps
 
       attr_reader :logger,
                   :root,

--- a/lib/buildkite/builder/schema.json
+++ b/lib/buildkite/builder/schema.json
@@ -1,0 +1,1454 @@
+{
+  "title": "JSON schema for Buildkite pipeline configuration files",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "fileMatch": [
+    "buildkite.yml",
+    "buildkite.yaml",
+    "buildkite.json",
+    "buildkite.*.yml",
+    "buildkite.*.yaml",
+    "buildkite.*.json",
+    ".buildkite/pipeline.yml",
+    ".buildkite/pipeline.yaml",
+    ".buildkite/pipeline.json",
+    ".buildkite/pipeline.*.yml",
+    ".buildkite/pipeline.*.yaml",
+    ".buildkite/pipeline.*.json"
+  ],
+  "type": "object",
+  "required": ["steps"],
+  "definitions": {
+    "allowDependencyFailure": {
+      "enum": [true, false, "true", "false"],
+      "description": "Whether to proceed with this step and further steps if a step named in the depends_on attribute fails",
+      "default": false
+    },
+    "image": {
+      "type": "string",
+      "description": "(Kubernetes stack only) The container image to use for this pipeline or step",
+      "examples": ["node:18-alpine", "python:3.11", "ubuntu:22.04"]
+    },
+    "allowedTeams": {
+      "description": "A list of teams that are permitted to unblock this step, whose values are a list of one or more team slugs or IDs",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ],
+      "examples": [
+        "frontend-team",
+        "96176d08-f503-413f-8423-96094953b9e7",
+        [
+          "frontend-team",
+          "backend-team",
+          "96176d08-f503-413f-8423-96094953b9e7"
+        ]
+      ]
+    },
+    "agents": {
+      "oneOf": [
+        { "$ref": "#/definitions/agentsObject" },
+        { "$ref": "#/definitions/agentsList" }
+      ]
+    },
+    "agentsObject": {
+      "type": "object",
+      "description": "Query rules to target specific agents",
+      "examples": [{ "queue": "deploy" }, { "ruby": "2*" }]
+    },
+    "agentsList": {
+      "type": "array",
+      "description": "Query rules to target specific agents in k=v format",
+      "examples": ["queue=default", "xcode=true"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "automaticRetry": {
+      "type": "object",
+      "properties": {
+        "exit_status": {
+          "description": "The exit status number that will cause this job to retry",
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": ["*"]
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "array",
+              "items": { "type": "integer" }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "description": "The number of times this job can be retried",
+          "minimum": 0,
+          "maximum": 10
+        },
+        "signal": {
+          "description": "The exit signal, if any, that may be retried",
+          "type": "string",
+          "examples": ["*", "none", "SIGKILL", "term"]
+        },
+        "signal_reason": {
+          "description": "The exit signal reason, if any, that may be retried",
+          "type": "string",
+          "enum": [
+            "*",
+            "none",
+            "agent_incompatible",
+            "agent_refused",
+            "agent_stop",
+            "cancel",
+            "process_run_error",
+            "signature_rejected",
+            "stack_error"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "branches": {
+      "description": "Which branches will include this step in their builds",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ],
+      "examples": ["master", ["feature/*", "chore/*"]]
+    },
+    "cache": {
+      "description": "The paths for the caches to be used in the step",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "paths": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "size": {
+              "type": "string",
+              "pattern": "^\\d+g$"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["paths"]
+        }
+      ],
+      "examples": [
+        "dist/",
+        [".build/*", "assets/*"],
+        {
+          "name": "cool-cache",
+          "size": "20g",
+          "paths": ["/path/one", "/path/two"]
+        }
+      ]
+    },
+    "cancelOnBuildFailing": {
+      "enum": [true, false, "true", "false"],
+      "description": "Whether to cancel the job as soon as the build is marked as failing",
+      "default": false
+    },
+    "dependsOnList": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "properties": {
+              "step": { "type": "string" },
+              "allow_failure": {
+                "enum": [true, false, "true", "false"],
+                "default": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "dependsOn": {
+      "description": "The step keys for a step to depend on",
+      "anyOf": [
+        { "type": "null" },
+        { "type": "string" },
+        { "$ref": "#/definitions/dependsOnList" }
+      ]
+    },
+    "env": {
+      "type": "object",
+      "description": "Environment variables for this step",
+      "examples": [{ "NODE_ENV": "test" }]
+    },
+    "if": {
+      "type": "string",
+      "description": "A boolean expression that omits the step when false",
+      "examples": ["build.message != 'skip me'", "build.branch == 'master'"]
+    },
+    "key": {
+      "type": "string",
+      "description": "A unique identifier for a step, must not resemble a UUID",
+      "examples": ["deploy-staging", "test-integration"],
+      "maxLength": 100,
+      "pattern": "^[a-zA-Z0-9_\\-:${}.,]+$",
+      "not": {
+        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      }
+    },
+    "label": {
+      "type": "string",
+      "description": "The label that will be displayed in the pipeline visualisation in Buildkite. Supports emoji.",
+      "examples": [":docker: Build"]
+    },
+    "notifySimple": {
+      "type": "string",
+      "enum": ["github_check", "github_commit_status"]
+    },
+    "notifyEmail": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notifyBasecamp": {
+      "type": "object",
+      "properties": {
+        "basecamp_campfire": {
+          "type": "string"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notifySlackObject": {
+      "type": "object",
+      "properties": {
+        "channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "notifySlack": {
+      "type": "object",
+      "properties": {
+        "slack": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/notifySlackObject"
+            }
+          ]
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notifyWebhook": {
+      "type": "object",
+      "properties": {
+        "webhook": {
+          "type": "string"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notifyPagerduty": {
+      "type": "object",
+      "properties": {
+        "pagerduty_change_event": {
+          "type": "string"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notifyGithubCommitStatus": {
+      "type": "object",
+      "properties": {
+        "github_commit_status": {
+          "type": "object",
+          "properties": {
+            "context": {
+              "description": "GitHub commit status name",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notifyGithubCheck": {
+      "type": "object",
+      "properties": {
+        "github_check": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "buildNotify": {
+      "type": "array",
+      "description": "Array of notification options for this step",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/notifySimple"
+          },
+          {
+            "$ref": "#/definitions/notifyEmail"
+          },
+          {
+            "$ref": "#/definitions/notifyBasecamp"
+          },
+          {
+            "$ref": "#/definitions/notifySlack"
+          },
+          {
+            "$ref": "#/definitions/notifyWebhook"
+          },
+          {
+            "$ref": "#/definitions/notifyPagerduty"
+          },
+          {
+            "$ref": "#/definitions/notifyGithubCommitStatus"
+          },
+          {
+            "$ref": "#/definitions/notifyGithubCheck"
+          }
+        ]
+      }
+    },
+    "textField": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The text input name",
+          "examples": ["Release Name"]
+        },
+        "key": {
+          "type": "string",
+          "description": "The meta-data key that stores the field's input",
+          "pattern": "^[a-zA-Z0-9-_]+$",
+          "examples": ["release-name"]
+        },
+        "hint": {
+          "type": "string",
+          "description": "The explanatory text that is shown after the label",
+          "examples": ["What’s the code name for this release? :name_badge:"]
+        },
+        "format": {
+          "type": "string",
+          "description": "The format must be a regular expression implicitly anchored to the beginning and end of the input and is functionally equivalent to the HTML5 pattern attribute.",
+          "format": "regex",
+          "examples": ["[0-9a-f]+"]
+        },
+        "required": {
+          "enum": [true, false, "true", "false"],
+          "default": true,
+          "description": "Whether the field is required for form submission"
+        },
+        "default": {
+          "type": "string",
+          "description": "The value that is pre-filled in the text field",
+          "examples": ["Flying Dolphin"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["key"]
+    },
+    "selectFieldOption": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The text displayed on the select list item",
+          "examples": ["Stable"]
+        },
+        "value": {
+          "type": "string",
+          "description": "The value to be stored as meta-data",
+          "examples": ["stable"]
+        },
+        "hint": {
+          "type": "string",
+          "description": "The text displayed directly under the select field’s label",
+          "examples": ["Which release stream does this belong in? :fork:"]
+        },
+        "required": {
+          "enum": [true, false, "true", "false"],
+          "default": true,
+          "description": "Whether the field is required for form submission"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["label", "value"]
+    },
+    "selectField": {
+      "type": "object",
+      "properties": {
+        "select": {
+          "type": "string",
+          "description": "The text input name",
+          "examples": ["Release Stream"]
+        },
+        "key": {
+          "type": "string",
+          "description": "The meta-data key that stores the field's input",
+          "pattern": "^[a-zA-Z0-9-_]+$",
+          "examples": ["release-stream"]
+        },
+        "default": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ],
+          "description": "The value of the option(s) that will be pre-selected in the dropdown",
+          "examples": ["beta", ["alpha", "beta"]]
+        },
+        "hint": {
+          "type": "string",
+          "description": "The explanatory text that is shown after the label",
+          "examples": ["What’s the code name for this release? :name_badge:"]
+        },
+        "multiple": {
+          "enum": [true, false, "true", "false"],
+          "description": "Whether more than one option may be selected",
+          "default": false
+        },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/selectFieldOption" }
+        },
+        "required": {
+          "enum": [true, false, "true", "false"],
+          "default": true,
+          "description": "Whether the field is required for form submission"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["key", "options"]
+    },
+    "fields": {
+      "type": "array",
+      "description": "A list of input fields required to be filled out before unblocking the step",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/textField" },
+          { "$ref": "#/definitions/selectField" }
+        ]
+      }
+    },
+    "ifChanged": {
+      "description": "Agent-applied attribute: A glob pattern that omits the step from a build if it does not match any files changed in the build. Can be a single pattern, list of patterns, or an object with include/exclude attributes.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A single glob pattern",
+          "examples": ["**.go", "go.{mod,sum}", "{app/**,spec/**}"]
+        },
+        {
+          "type": "array",
+          "description": "A list of glob patterns",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            ["**.go", "go.{mod,sum}"],
+            ["app/**", "spec/**"]
+          ]
+        },
+        {
+          "type": "object",
+          "description": "An object with include and optional exclude patterns",
+          "properties": {
+            "include": {
+              "description": "Pattern or list of patterns to include",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "exclude": {
+              "description": "Pattern or list of patterns to exclude",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            }
+          },
+          "required": ["include"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "matrixElement": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "boolean" }
+      ]
+    },
+    "prompt": {
+      "type": "string",
+      "description": "The instructional message displayed in the dialog box when the unblock step is activated",
+      "examples": ["Release to production?"]
+    },
+    "skip": {
+      "anyOf": [
+        { "type": "boolean" },
+        {
+          "type": "string",
+          "maxLength": 70
+        }
+      ],
+      "description": "Whether this step should be skipped. Passing a string provides a reason for skipping this command",
+      "examples": [true, false, "My reason"]
+    },
+    "secrets": {
+      "description": "A list of secret names or a mapping of environment variable names to secret names to be made available to the build or step",
+      "anyOf": [
+        {
+          "type": "array",
+          "description": "A list of secret names to be made available as environment variables",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["API_ACCESS_TOKEN"], ["API_KEY", "DATABASE_PASSWORD"]]
+        },
+        {
+          "type": "object",
+          "description": "A mapping of custom environment variable names to Buildkite secret names",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "examples": [
+            { "MY_APP_ACCESS_TOKEN": "API_ACCESS_TOKEN" },
+            {
+              "CUSTOM_API_KEY": "API_KEY",
+              "CUSTOM_DB_PASSWORD": "DATABASE_PASSWORD"
+            }
+          ]
+        }
+      ]
+    },
+    "softFailObject": {
+      "type": "object",
+      "properties": {
+        "exit_status": {
+          "description": "The exit status number that will cause this job to soft-fail",
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": ["*"]
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        }
+      }
+    },
+    "softFailList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/softFailObject"
+      }
+    },
+    "softFail": {
+      "description": "The conditions for marking the step as a soft-fail.",
+      "anyOf": [
+        {
+          "enum": [true, false, "true", "false"]
+        },
+        {
+          "$ref": "#/definitions/softFailList"
+        }
+      ]
+    },
+    "blockStep": {
+      "type": "object",
+      "properties": {
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/allowDependencyFailure"
+        },
+        "block": {
+          "type": "string",
+          "description": "The label of the block step"
+        },
+        "blocked_state": {
+          "type": "string",
+          "default": "passed",
+          "description": "The state that the build is set to when the build is blocked by this block step",
+          "enum": ["passed", "failed", "running"]
+        },
+        "branches": {
+          "$ref": "#/definitions/branches"
+        },
+        "depends_on": {
+          "$ref": "#/definitions/dependsOn"
+        },
+        "fields": {
+          "$ref": "#/definitions/fields"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        },
+        "key": {
+          "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/blockStep/properties/key"
+        },
+        "id": {
+          "$ref": "#/definitions/blockStep/properties/key",
+          "deprecated": true
+        },
+        "label": {
+          "$ref": "#/definitions/blockStep/properties/block"
+        },
+        "name": {
+          "$ref": "#/definitions/blockStep/properties/block"
+        },
+        "prompt": {
+          "$ref": "#/definitions/prompt"
+        },
+        "allowed_teams": {
+          "$ref": "#/definitions/allowedTeams"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["block"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "nestedBlockStep": {
+      "type": "object",
+      "properties": {
+        "block": {
+          "$ref": "#/definitions/blockStep"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stringBlockStep": {
+      "type": "string",
+      "description": "Pauses the execution of a build and waits on a user to unblock it",
+      "enum": ["block"]
+    },
+    "inputStep": {
+      "type": "object",
+      "properties": {
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/allowDependencyFailure"
+        },
+        "input": {
+          "type": "string",
+          "description": "The label of the input step"
+        },
+        "branches": {
+          "$ref": "#/definitions/branches"
+        },
+        "depends_on": {
+          "$ref": "#/definitions/dependsOn"
+        },
+        "fields": {
+          "$ref": "#/definitions/fields"
+        },
+        "blocked_state": {
+          "type": "string",
+          "default": "passed",
+          "description": "The state that the build is set to when the build is blocked by this input step",
+          "enum": ["passed", "failed", "running"]
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        },
+        "key": {
+          "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/inputStep/properties/key"
+        },
+        "id": {
+          "$ref": "#/definitions/inputStep/properties/key",
+          "deprecated": true
+        },
+        "label": {
+          "$ref": "#/definitions/inputStep/properties/input"
+        },
+        "name": {
+          "$ref": "#/definitions/inputStep/properties/input"
+        },
+        "prompt": {
+          "$ref": "#/definitions/prompt"
+        },
+        "allowed_teams": {
+          "$ref": "#/definitions/allowedTeams"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["input"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "nestedInputStep": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "$ref": "#/definitions/inputStep"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stringInputStep": {
+      "type": "string",
+      "description": "Pauses the execution of a build and waits on a user to unblock it",
+      "enum": ["input"]
+    },
+    "matrixElementList": {
+      "type": "array",
+      "description": "List of elements for single-dimension Build Matrix",
+      "items": { "$ref": "#/definitions/matrixElement" },
+      "examples": [["linux", "freebsd"]]
+    },
+    "matrixSetup": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/matrixElementList"
+        },
+        {
+          "type": "object",
+          "description": "Mapping of Build Matrix dimension names to their lists of elements",
+          "propertyNames": {
+            "type": "string",
+            "description": "Build Matrix dimension name",
+            "pattern": "^[a-zA-Z0-9_]+$"
+          },
+          "additionalProperties": {
+            "type": "array",
+            "description": "List of elements for this Build Matrix dimension",
+            "items": { "$ref": "#/definitions/matrixElement" }
+          },
+          "examples": [
+            {
+              "os": ["linux", "freebsd"],
+              "arch": ["arm64", "riscv"]
+            }
+          ]
+        }
+      ]
+    },
+    "matrixAdjustmentsWithObject": {
+      "type": "object",
+      "description": "Specification of a new or existing Build Matrix combination",
+      "propertyNames": {
+        "type": "string",
+        "description": "Build Matrix dimension name"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "description": "Build Matrix dimension element"
+      },
+      "examples": [{ "os": "linux", "arch": "arm64" }]
+    },
+    "matrixAdjustments": {
+      "type": "object",
+      "description": "An adjustment to a Build Matrix",
+      "properties": {
+        "with": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/matrixElementList"
+            },
+            {
+              "$ref": "#/definitions/matrixAdjustmentsWithObject"
+            }
+          ]
+        },
+        "skip": {
+          "$ref": "#/definitions/skip"
+        },
+        "soft_fail": {
+          "$ref": "#/definitions/softFail"
+        }
+      },
+      "required": ["with"]
+    },
+    "matrixObject": {
+      "type": "object",
+      "description": "Configuration for multi-dimension Build Matrix",
+      "properties": {
+        "setup": {
+          "$ref": "#/definitions/matrixSetup"
+        },
+        "adjustments": {
+          "type": "array",
+          "description": "List of Build Matrix adjustments",
+          "items": {
+            "$ref": "#/definitions/matrixAdjustments"
+          }
+        }
+      },
+      "required": ["setup"]
+    },
+    "matrix": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/matrixElementList"
+        },
+        {
+          "$ref": "#/definitions/matrixObject"
+        }
+      ]
+    },
+    "commandStepCommand": {
+      "description": "The commands to run on the agent",
+      "anyOf": [
+        { "type": "array", "items": { "type": "string" } },
+        { "type": "string" }
+      ]
+    },
+    "commandStepNotify": {
+      "type": "array",
+      "description": "Array of notification options for this step",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/notifySimple"
+          },
+          {
+            "$ref": "#/definitions/notifyBasecamp"
+          },
+          {
+            "$ref": "#/definitions/notifySlack"
+          },
+          {
+            "$ref": "#/definitions/notifyGithubCommitStatus"
+          },
+          {
+            "$ref": "#/definitions/notifyGithubCheck"
+          }
+        ]
+      }
+    },
+    "pluginsList": {
+      "type": "array",
+      "description": "Array of plugins for this step",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "maxProperties": 1,
+            "examples": [{ "docker-compose#v1.0.0": { "run": "app" } }]
+          }
+        ]
+      }
+    },
+    "pluginsObject": {
+      "type": "object",
+      "description": "A map of plugins for this step. Deprecated: please use the array syntax.",
+      "deprecated": true
+    },
+    "plugins": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/pluginsList"
+        },
+        {
+          "$ref": "#/definitions/pluginsObject"
+        }
+      ]
+    },
+    "automaticRetryList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/automaticRetry"
+      }
+    },
+    "commandStepAutomaticRetry": {
+      "anyOf": [
+        {
+          "enum": [true, false, "true", "false"]
+        },
+        {
+          "$ref": "#/definitions/automaticRetry"
+        },
+        {
+          "$ref": "#/definitions/automaticRetryList"
+        }
+      ],
+      "description": "Whether to allow a job to retry automatically. If set to true, the retry conditions are set to the default value.",
+      "default": [
+        {
+          "exit_status": "*",
+          "limit": 2
+        }
+      ]
+    },
+    "commandStepManualRetryObject": {
+      "type": "object",
+      "properties": {
+        "allowed": {
+          "enum": [true, false, "true", "false"],
+          "description": "Whether or not this job can be retried manually",
+          "default": true
+        },
+        "permit_on_passed": {
+          "enum": [true, false, "true", "false"],
+          "description": "Whether or not this job can be retried after it has passed",
+          "default": true
+        },
+        "reason": {
+          "type": "string",
+          "description": "A string that will be displayed in a tooltip on the Retry button in Buildkite. This will only be displayed if the allowed attribute is set to false.",
+          "examples": ["No retries allowed on deploy steps"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "commandStepManualRetry": {
+      "description": "Whether to allow a job to be retried manually",
+      "anyOf": [
+        {
+          "enum": [true, false, "true", "false"]
+        },
+        {
+          "$ref": "#/definitions/commandStepManualRetryObject"
+        }
+      ],
+      "default": true
+    },
+    "commandStep": {
+      "type": "object",
+      "properties": {
+        "agents": {
+          "$ref": "#/definitions/agents"
+        },
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/allowDependencyFailure"
+        },
+        "artifact_paths": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ],
+          "description": "The glob path/s of artifacts to upload once this step has finished running",
+          "examples": [["screenshots/*"], ["dist/myapp.zip", "dist/myapp.tgz"]]
+        },
+        "branches": {
+          "$ref": "#/definitions/branches"
+        },
+        "cache": {
+          "$ref": "#/definitions/cache"
+        },
+        "cancel_on_build_failing": {
+          "$ref": "#/definitions/cancelOnBuildFailing"
+        },
+        "command": {
+          "$ref": "#/definitions/commandStepCommand"
+        },
+        "commands": {
+          "$ref": "#/definitions/commandStepCommand"
+        },
+        "concurrency": {
+          "type": "integer",
+          "description": "The maximum number of jobs created from this step that are allowed to run at the same time. If you use this attribute, you must also define concurrency_group.",
+          "examples": [1]
+        },
+        "concurrency_group": {
+          "type": "string",
+          "description": "A unique name for the concurrency group that you are creating with the concurrency attribute",
+          "examples": ["my-pipeline/deploy"]
+        },
+        "concurrency_method": {
+          "type": "string",
+          "enum": ["ordered", "eager"],
+          "description": "Control command order, allowed values are 'ordered' (default) and 'eager'.  If you use this attribute, you must also define concurrency_group and concurrency.",
+          "examples": ["ordered"]
+        },
+        "depends_on": {
+          "$ref": "#/definitions/dependsOn"
+        },
+        "env": {
+          "$ref": "#/definitions/env"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        },
+        "if_changed": {
+          "$ref": "#/definitions/ifChanged"
+        },
+        "key": {
+          "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/commandStep/properties/key"
+        },
+        "id": {
+          "$ref": "#/definitions/commandStep/properties/key",
+          "deprecated": true
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "label": {
+          "$ref": "#/definitions/label"
+        },
+        "signature": {
+          "type": "object",
+          "description": "The signature of the command step, generally injected by agents at pipeline upload",
+          "properties": {
+            "algorithm": {
+              "type": "string",
+              "description": "The algorithm used to generate the signature",
+              "examples": ["HS512", "EdDSA", "PS256"]
+            },
+            "value": {
+              "type": "string",
+              "description": "The signature value, a JWS compact signature with a detached body"
+            },
+            "signed_fields": {
+              "type": "array",
+              "description": "The fields that were signed to form the signature value",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                ["command", "matrix", "plugins", "env::SOME_ENV_VAR"]
+              ]
+            }
+          }
+        },
+        "matrix": {
+          "$ref": "#/definitions/matrix"
+        },
+        "name": {
+          "$ref": "#/definitions/commandStep/properties/label"
+        },
+        "notify": {
+          "$ref": "#/definitions/commandStepNotify"
+        },
+        "parallelism": {
+          "type": "integer",
+          "description": "The number of parallel jobs that will be created based on this step",
+          "examples": [42]
+        },
+        "plugins": {
+          "$ref": "#/definitions/plugins"
+        },
+        "soft_fail": {
+          "$ref": "#/definitions/softFail"
+        },
+        "retry": {
+          "type": "object",
+          "description": "The conditions for retrying this step.",
+          "properties": {
+            "automatic": {
+              "$ref": "#/definitions/commandStepAutomaticRetry"
+            },
+            "manual": {
+              "$ref": "#/definitions/commandStepManualRetry"
+            }
+          },
+          "additionalProperties": false
+        },
+        "skip": {
+          "$ref": "#/definitions/skip"
+        },
+        "timeout_in_minutes": {
+          "type": "integer",
+          "description": "The number of minutes to time out a job",
+          "minimum": 1,
+          "examples": [60]
+        },
+        "type": {
+          "type": "string",
+          "enum": ["script", "command", "commands"]
+        },
+        "priority": {
+          "$ref": "#/definitions/priority"
+        },
+        "secrets": {
+          "$ref": "#/definitions/secrets"
+        }
+      },
+      "additionalProperties": false
+    },
+    "nestedCommandStep": {
+      "type": "object",
+      "properties": {
+        "command": { "$ref": "#/definitions/commandStep" },
+        "commands": { "$ref": "#/definitions/commandStep" },
+        "script": { "$ref": "#/definitions/commandStep" }
+      },
+      "additionalProperties": false
+    },
+    "stringWaitStep": {
+      "type": "string",
+      "description": "Waits for previous steps to pass before continuing",
+      "enum": ["wait", "waiter"]
+    },
+    "waitStep": {
+      "type": "object",
+      "properties": {
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/allowDependencyFailure"
+        },
+        "branches": {
+          "$ref": "#/definitions/branches"
+        },
+        "continue_on_failure": {
+          "description": "Continue to the next steps, even if the previous group of steps fail",
+          "enum": [true, false, "true", "false"],
+          "default": false
+        },
+        "depends_on": {
+          "$ref": "#/definitions/dependsOn"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        },
+        "key": {
+          "$ref": "#/definitions/key"
+        },
+        "label": {
+          "$ref": "#/definitions/waitStep/properties/wait"
+        },
+        "name": {
+          "$ref": "#/definitions/waitStep/properties/wait"
+        },
+        "identifier": {
+          "$ref": "#/definitions/waitStep/properties/key"
+        },
+        "id": {
+          "$ref": "#/definitions/waitStep/properties/key",
+          "deprecated": true
+        },
+        "type": {
+          "type": "string",
+          "enum": ["wait", "waiter"]
+        },
+        "wait": {
+          "description": "Waits for previous steps to pass before continuing",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "nestedWaitStep": {
+      "type": "object",
+      "properties": {
+        "wait": {
+          "description": "Waits for previous steps to pass before continuing",
+          "$ref": "#/definitions/waitStep"
+        },
+        "waiter": {
+          "$ref": "#/definitions/waitStep"
+        }
+      },
+      "additionalProperties": false
+    },
+    "triggerStep": {
+      "type": "object",
+      "properties": {
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/allowDependencyFailure"
+        },
+        "async": {
+          "enum": [true, false, "true", "false"],
+          "default": false,
+          "description": "Whether to continue the build without waiting for the triggered step to complete"
+        },
+        "branches": {
+          "$ref": "#/definitions/branches"
+        },
+        "build": {
+          "type": "object",
+          "description": "Properties of the build that will be created when the step is triggered",
+          "properties": {
+            "branch": {
+              "type": "string",
+              "description": "The branch for the build",
+              "default": "master",
+              "examples": ["master", "feature/xyz"]
+            },
+            "commit": {
+              "type": "string",
+              "description": "The commit hash for the build",
+              "default": "HEAD",
+              "examples": ["HEAD", "b5fb108"]
+            },
+            "env": {
+              "$ref": "#/definitions/env"
+            },
+            "message": {
+              "type": "string",
+              "description": "The message for the build (supports emoji)",
+              "default": "The label of the trigger step",
+              "examples": ["Deployment 123 :rocket:"]
+            },
+            "meta_data": {
+              "type": "object",
+              "description": "Meta-data for the build",
+              "examples": [{ "server": "i-b244e37160c" }]
+            }
+          },
+          "additionalProperties": false
+        },
+        "depends_on": {
+          "$ref": "#/definitions/dependsOn"
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        },
+        "if_changed": {
+          "$ref": "#/definitions/ifChanged"
+        },
+        "key": {
+          "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/triggerStep/properties/key"
+        },
+        "id": {
+          "$ref": "#/definitions/triggerStep/properties/key",
+          "deprecated": true
+        },
+        "label": {
+          "$ref": "#/definitions/label"
+        },
+        "name": {
+          "$ref": "#/definitions/triggerStep/properties/label"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["trigger"]
+        },
+        "trigger": {
+          "type": "string",
+          "description": "The slug of the pipeline to create a build"
+        },
+        "skip": {
+          "$ref": "#/definitions/skip"
+        },
+        "soft_fail": {
+          "$ref": "#/definitions/softFail"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["trigger"]
+    },
+    "nestedTriggerStep": {
+      "type": "object",
+      "properties": {
+        "trigger": {
+          "$ref": "#/definitions/triggerStep"
+        }
+      },
+      "additionalProperties": false
+    },
+    "groupSteps": {
+      "type": "array",
+      "description": "A list of steps",
+      "items": {
+        "anyOf": [
+          { "$ref": "#/definitions/blockStep" },
+          { "$ref": "#/definitions/nestedBlockStep" },
+          { "$ref": "#/definitions/stringBlockStep" },
+          { "$ref": "#/definitions/inputStep" },
+          { "$ref": "#/definitions/nestedInputStep" },
+          { "$ref": "#/definitions/stringInputStep" },
+          { "$ref": "#/definitions/commandStep" },
+          { "$ref": "#/definitions/nestedCommandStep" },
+          { "$ref": "#/definitions/waitStep" },
+          { "$ref": "#/definitions/nestedWaitStep" },
+          { "$ref": "#/definitions/stringWaitStep" },
+          { "$ref": "#/definitions/triggerStep" },
+          { "$ref": "#/definitions/nestedTriggerStep" }
+        ]
+      },
+      "minItems": 1
+    },
+    "groupStep": {
+      "type": "object",
+      "properties": {
+        "depends_on": {
+          "$ref": "#/definitions/dependsOn"
+        },
+        "group": {
+          "type": ["string", "null"],
+          "description": "The name to give to this group of steps",
+          "examples": ["Tests"]
+        },
+        "if": {
+          "$ref": "#/definitions/if"
+        },
+        "if_changed": {
+          "$ref": "#/definitions/ifChanged"
+        },
+        "key": {
+          "$ref": "#/definitions/key"
+        },
+        "identifier": {
+          "$ref": "#/definitions/groupStep/properties/key"
+        },
+        "id": {
+          "$ref": "#/definitions/groupStep/properties/key",
+          "deprecated": true
+        },
+        "label": {
+          "$ref": "#/definitions/groupStep/properties/group"
+        },
+        "name": {
+          "$ref": "#/definitions/groupStep/properties/group"
+        },
+        "allow_dependency_failure": {
+          "$ref": "#/definitions/allowDependencyFailure"
+        },
+        "notify": {
+          "$ref": "#/definitions/buildNotify"
+        },
+        "skip": {
+          "$ref": "#/definitions/skip"
+        },
+        "steps": {
+          "$ref": "#/definitions/groupSteps"
+        }
+      },
+      "required": ["group", "steps"],
+      "additionalProperties": false
+    },
+    "pipelineSteps": {
+      "description": "A list of steps",
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "$ref": "#/definitions/blockStep" },
+          { "$ref": "#/definitions/nestedBlockStep" },
+          { "$ref": "#/definitions/stringBlockStep" },
+          { "$ref": "#/definitions/inputStep" },
+          { "$ref": "#/definitions/nestedInputStep" },
+          { "$ref": "#/definitions/stringInputStep" },
+          { "$ref": "#/definitions/commandStep" },
+          { "$ref": "#/definitions/nestedCommandStep" },
+          { "$ref": "#/definitions/waitStep" },
+          { "$ref": "#/definitions/nestedWaitStep" },
+          { "$ref": "#/definitions/stringWaitStep" },
+          { "$ref": "#/definitions/triggerStep" },
+          { "$ref": "#/definitions/nestedTriggerStep" },
+          { "$ref": "#/definitions/groupStep" }
+        ]
+      }
+    },
+    "priority": {
+      "type": "integer",
+      "description": "Priority of all jobs in the pipeline, higher priorities are assigned to agents. When set pipeline-wide, it applies to all steps that do not have their own priority key set.",
+      "examples": [-1, 0, 10]
+    }
+  },
+  "properties": {
+    "env": {
+      "$ref": "#/definitions/env"
+    },
+    "agents": {
+      "$ref": "#/definitions/agents"
+    },
+    "notify": {
+      "$ref": "#/definitions/buildNotify"
+    },
+    "image": {
+      "$ref": "#/definitions/image"
+    },
+    "secrets": {
+      "$ref": "#/definitions/secrets"
+    },
+    "priority": {
+      "$ref": "#/definitions/priority"
+    },
+    "steps": {
+      "$ref": "#/definitions/pipelineSteps"
+    }
+  }
+}

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -9,16 +9,15 @@ module Buildkite
       using Rainbow
 
       class ValidationError
-        attr_reader :pointer, :type, :schema, :data, :details, :message, :source_location
+        attr_reader :source_location
 
-        def initialize(pointer: '', type: nil, schema: nil, data: nil, details: nil, message: nil, source_location: nil)
-          @pointer = pointer
-          @type = type
-          @schema = schema
-          @data = data
-          @details = details
-          @message = message
+        def initialize(error = {}, source_location: nil)
+          @error = error
           @source_location = source_location
+        end
+
+        def pointer
+          @error['data_pointer'] || ''
         end
 
         def attribute
@@ -27,29 +26,30 @@ module Buildkite
         end
 
         def formatted_message
-          case type
+          case @error['type']
           when 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null'
+            type = @error['type']
             article = type.match?(/\A[aeiou]/) ? 'an' : 'a'
             "must be #{article} #{type}"
           when 'enum'
-            values = schema['enum'].map(&:inspect).join(', ')
+            values = @error.dig('schema', 'enum').map(&:inspect).join(', ')
             "must be one of: #{values}"
           when 'required'
-            missing = details&.dig('missing_keys') || schema['required']
+            missing = @error.dig('details', 'missing_keys') || @error.dig('schema', 'required')
             missing = missing.join(', ') if missing.is_a?(Array)
             "is missing required attributes: #{missing}"
           when 'additionalProperties', 'schema'
             "is not a recognized attribute"
           when 'minimum'
-            "must be at least #{schema['minimum']}"
+            "must be at least #{@error.dig('schema', 'minimum')}"
           when 'maximum'
-            "must be at most #{schema['maximum']}"
+            "must be at most #{@error.dig('schema', 'maximum')}"
           when 'pattern'
             "does not match expected format"
           when 'minItems'
-            "must have at least #{schema['minItems']} item(s)"
+            "must have at least #{@error.dig('schema', 'minItems')} item(s)"
           else
-            message
+            @error['error']
           end
         end
 
@@ -78,7 +78,7 @@ module Buildkite
 
       def validate(pipeline_hash)
         @schemer.validate(pipeline_hash).map do |error|
-          build_error(error)
+          ValidationError.new(error)
         end
       end
 
@@ -119,18 +119,6 @@ module Buildkite
 
       private
 
-      def build_error(error, source_location: nil)
-        ValidationError.new(
-          pointer: error['data_pointer'],
-          type: error['type'],
-          schema: error['schema'],
-          data: error['data'],
-          details: error['details'],
-          message: error['error'],
-          source_location: source_location
-        )
-      end
-
       def validate_steps(step_hashes, step_objects)
         errors = []
         step_hashes.each_with_index do |step_hash, index|
@@ -155,7 +143,7 @@ module Buildkite
           return [] unless step_schemer
 
           step_schemer.validate(step_hash).map do |error|
-            build_error(error, source_location: step_obj.source_location)
+            ValidationError.new(error, source_location: step_obj.source_location)
           end
         end
       end

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -7,7 +7,20 @@ module Buildkite
   module Builder
     class Validator
       using Rainbow
-      ValidationError = Struct.new(:pointer, :type, :schema, :data, :details, :message, :source_location, keyword_init: true) do
+
+      class ValidationError
+        attr_reader :pointer, :type, :schema, :data, :details, :message, :source_location
+
+        def initialize(pointer: '', type: nil, schema: nil, data: nil, details: nil, message: nil, source_location: nil)
+          @pointer = pointer
+          @type = type
+          @schema = schema
+          @data = data
+          @details = details
+          @message = message
+          @source_location = source_location
+        end
+
         def attribute
           segment = pointer.split('/').last
           segment && !segment.empty? ? segment : 'pipeline'

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -6,37 +6,41 @@ require 'pathname'
 module Buildkite
   module Builder
     class Validator
-      ValidationError = Struct.new(:pointer, :message, :source_location, keyword_init: true) do
+      ValidationError = Struct.new(:pointer, :type, :schema, :data, :message, :source_location, keyword_init: true) do
         def attribute
           pointer.split('/').last
         end
 
         def formatted_message
-          normalize_message(message, attribute)
+          case type
+          when 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null'
+            article = type.match?(/\A[aeiou]/) ? 'an' : 'a'
+            "must be #{article} #{type}"
+          when 'enum'
+            values = schema['enum'].map(&:inspect).join(', ')
+            "must be one of: #{values}"
+          when 'required'
+            missing = schema['required']
+            missing = missing.join(', ') if missing.is_a?(Array)
+            "is missing required attributes: #{missing}"
+          when 'additionalProperties', 'schema'
+            "is not a recognized attribute"
+          when 'minimum'
+            "must be at least #{schema['minimum']}"
+          when 'maximum'
+            "must be at most #{schema['maximum']}"
+          when 'pattern'
+            "does not match expected format"
+          when 'minItems'
+            "must have at least #{schema['minItems']} item(s)"
+          else
+            message
+          end
         end
 
         def to_s
           location = source_location ? "#{source_location.file}:#{source_location.line_number}  " : ''
           "#{location}'#{attribute}': #{formatted_message}"
-        end
-
-        private
-
-        # Translate json_schemer's raw error into DSL-friendly language.
-        def normalize_message(msg, attr)
-          case msg
-          when /is not an? (\w+)$/
-            article = %w[array integer object].include?($1) ? 'an' : 'a'
-            "must be #{article} #{$1}"
-          when /is not one of: (.+)$/
-            "must be one of #{$1}"
-          when /is a disallowed additional property$/
-            "is not a recognized attribute"
-          when /is missing required properties: (.+)$/
-            "is missing required attributes: #{$1}"
-          else
-            msg.sub(/\A(value|object|object property) at `\/[^`]*` /, '')
-          end
         end
       end
 
@@ -59,10 +63,7 @@ module Buildkite
 
       def validate(pipeline_hash)
         @schemer.validate(pipeline_hash).map do |error|
-          ValidationError.new(
-            pointer: error['data_pointer'],
-            message: error['error']
-          )
+          build_error(error)
         end
       end
 
@@ -92,6 +93,17 @@ module Buildkite
 
       private
 
+      def build_error(error, source_location: nil)
+        ValidationError.new(
+          pointer: error['data_pointer'],
+          type: error['type'],
+          schema: error['schema'],
+          data: error['data'],
+          message: error['error'],
+          source_location: source_location
+        )
+      end
+
       def validate_steps(step_hashes, step_objects)
         errors = []
         step_hashes.each_with_index do |step_hash, index|
@@ -116,11 +128,7 @@ module Buildkite
           return [] unless step_schemer
 
           step_schemer.validate(step_hash).map do |error|
-            ValidationError.new(
-              pointer: error['data_pointer'],
-              message: error['error'],
-              source_location: step_obj.source_location
-            )
+            build_error(error, source_location: step_obj.source_location)
           end
         end
       end

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -90,7 +90,18 @@ module Buildkite
       end
 
       def self.default_schemer
-        @default_schemer ||= JSONSchemer.schema(Pathname.new(default_schema_path.to_s))
+        @default_schemer ||= suppress_warnings { JSONSchemer.schema(Pathname.new(default_schema_path.to_s)) }
+      end
+
+      # The Buildkite schema contains regex patterns with unescaped hyphens in
+      # character classes (e.g. /^[a-zA-Z0-9-_]+$/), which trigger harmless
+      # Ruby warnings when json_schemer compiles them.
+      def self.suppress_warnings
+        original = $VERBOSE
+        $VERBOSE = nil
+        yield
+      ensure
+        $VERBOSE = original
       end
 
       private

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -6,9 +6,10 @@ require 'pathname'
 module Buildkite
   module Builder
     class Validator
-      ValidationError = Struct.new(:pointer, :type, :schema, :data, :message, :source_location, keyword_init: true) do
+      ValidationError = Struct.new(:pointer, :type, :schema, :data, :details, :message, :source_location, keyword_init: true) do
         def attribute
-          pointer.split('/').last
+          segment = pointer.split('/').last
+          segment && !segment.empty? ? segment : 'pipeline'
         end
 
         def formatted_message
@@ -20,7 +21,7 @@ module Buildkite
             values = schema['enum'].map(&:inspect).join(', ')
             "must be one of: #{values}"
           when 'required'
-            missing = schema['required']
+            missing = details&.dig('missing_keys') || schema['required']
             missing = missing.join(', ') if missing.is_a?(Array)
             "is missing required attributes: #{missing}"
           when 'additionalProperties', 'schema'
@@ -39,7 +40,7 @@ module Buildkite
         end
 
         def to_s
-          location = source_location ? "#{source_location.file}:#{source_location.line_number}  " : ''
+          location = source_location ? "#{source_location.file}:#{source_location.line_number} " : ''
           "#{location}'#{attribute}': #{formatted_message}"
         end
       end
@@ -99,6 +100,7 @@ module Buildkite
           type: error['type'],
           schema: error['schema'],
           data: error['data'],
+          details: error['details'],
           message: error['error'],
           source_location: source_location
         )

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -6,6 +6,7 @@ require 'pathname'
 module Buildkite
   module Builder
     class Validator
+      using Rainbow
       ValidationError = Struct.new(:pointer, :type, :schema, :data, :details, :message, :source_location, keyword_init: true) do
         def attribute
           segment = pointer.split('/').last
@@ -40,8 +41,8 @@ module Buildkite
         end
 
         def to_s
-          location = source_location ? "#{source_location.file}:#{source_location.line_number} " : ''
-          "#{location}'#{attribute}': #{formatted_message}"
+          location = source_location ? "#{source_location.file}:#{source_location.line_number}".color(:dimgray) + ' ' : ''
+          "#{location}#{attribute.bright}: #{formatted_message}"
         end
       end
 

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -6,7 +6,39 @@ require 'pathname'
 module Buildkite
   module Builder
     class Validator
-      ValidationError = Struct.new(:pointer, :message, :source_location, keyword_init: true)
+      ValidationError = Struct.new(:pointer, :message, :source_location, keyword_init: true) do
+        def attribute
+          pointer.split('/').last
+        end
+
+        def formatted_message
+          normalize_message(message, attribute)
+        end
+
+        def to_s
+          location = source_location ? "#{source_location.file}:#{source_location.line_number}  " : ''
+          "#{location}'#{attribute}': #{formatted_message}"
+        end
+
+        private
+
+        # Translate json_schemer's raw error into DSL-friendly language.
+        def normalize_message(msg, attr)
+          case msg
+          when /is not an? (\w+)$/
+            article = %w[array integer object].include?($1) ? 'an' : 'a'
+            "must be #{article} #{$1}"
+          when /is not one of: (.+)$/
+            "must be one of #{$1}"
+          when /is a disallowed additional property$/
+            "is not a recognized attribute"
+          when /is missing required properties: (.+)$/
+            "is missing required attributes: #{$1}"
+          else
+            msg.sub(/\A(value|object|object property) at `\/[^`]*` /, '')
+          end
+        end
+      end
 
       STEP_SCHEMA_MAP = {
         Pipelines::Steps::Command => 'commandStep',

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -9,17 +9,20 @@ module Buildkite
       ValidationError = Struct.new(:pointer, :message, :source_location, keyword_init: true)
 
       STEP_SCHEMA_MAP = {
-        'Buildkite::Pipelines::Steps::Command' => 'commandStep',
-        'Buildkite::Pipelines::Steps::Block' => 'blockStep',
-        'Buildkite::Pipelines::Steps::Input' => 'inputStep',
-        'Buildkite::Pipelines::Steps::Trigger' => 'triggerStep',
-        'Buildkite::Pipelines::Steps::Wait' => 'waitStep',
-        'Buildkite::Pipelines::Steps::Group' => 'groupStep',
+        Pipelines::Steps::Command => 'commandStep',
+        Pipelines::Steps::Block   => 'blockStep',
+        Pipelines::Steps::Input   => 'inputStep',
+        Pipelines::Steps::Trigger => 'triggerStep',
+        Pipelines::Steps::Wait    => 'waitStep',
+        Pipelines::Steps::Group   => 'groupStep',
       }.freeze
 
       def initialize(schema_path: nil)
-        path = schema_path || self.class.default_schema_path
-        @schemer = JSONSchemer.schema(Pathname.new(path.to_s))
+        @schemer = if schema_path
+          JSONSchemer.schema(Pathname.new(schema_path.to_s))
+        else
+          self.class.default_schemer
+        end
       end
 
       def validate(pipeline_hash)
@@ -35,19 +38,24 @@ module Buildkite
         @schemer.valid?(pipeline_hash)
       end
 
-      # Validates both the full pipeline and each step against its type-specific
-      # sub-schema. Step errors include source locations for precise error reporting.
       def validate_all(pipeline_hash, step_collection = nil)
-        errors = validate(pipeline_hash)
         if step_collection
+          # Suppress per-step errors from the top-level pass; per-step validation
+          # below catches the same violations with source location context.
+          pipeline_errors = validate(pipeline_hash).reject { |e| e.pointer.start_with?('/steps/') }
           step_hashes = pipeline_hash['steps'] || []
-          errors += validate_steps(step_hashes, step_collection.steps)
+          pipeline_errors + validate_steps(step_hashes, step_collection.steps)
+        else
+          validate(pipeline_hash)
         end
-        errors
       end
 
       def self.default_schema_path
         File.expand_path('schema.json', __dir__)
+      end
+
+      def self.default_schemer
+        @default_schemer ||= JSONSchemer.schema(Pathname.new(default_schema_path.to_s))
       end
 
       private
@@ -69,7 +77,7 @@ module Buildkite
           nested_objects = step_obj.steps.steps
           validate_steps(nested_hashes, nested_objects)
         else
-          definition_name = STEP_SCHEMA_MAP[step_obj.class.name]
+          definition_name = STEP_SCHEMA_MAP[step_obj.class]
           return [] unless definition_name
 
           step_schemer = @schemer.ref("#/definitions/#{definition_name}")

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+require 'pathname'
+
+module Buildkite
+  module Builder
+    class Validator
+      ValidationError = Struct.new(:pointer, :message, keyword_init: true)
+
+      def initialize(schema_path: nil)
+        path = schema_path || self.class.default_schema_path
+        @schemer = JSONSchemer.schema(Pathname.new(path.to_s))
+      end
+
+      def validate(pipeline_hash)
+        @schemer.validate(pipeline_hash).map do |error|
+          ValidationError.new(
+            pointer: error['data_pointer'],
+            message: error['error']
+          )
+        end
+      end
+
+      def valid?(pipeline_hash)
+        @schemer.valid?(pipeline_hash)
+      end
+
+      def self.default_schema_path
+        File.expand_path('schema.json', __dir__)
+      end
+    end
+  end
+end

--- a/lib/buildkite/builder/validator.rb
+++ b/lib/buildkite/builder/validator.rb
@@ -6,7 +6,16 @@ require 'pathname'
 module Buildkite
   module Builder
     class Validator
-      ValidationError = Struct.new(:pointer, :message, keyword_init: true)
+      ValidationError = Struct.new(:pointer, :message, :source_location, keyword_init: true)
+
+      STEP_SCHEMA_MAP = {
+        'Buildkite::Pipelines::Steps::Command' => 'commandStep',
+        'Buildkite::Pipelines::Steps::Block' => 'blockStep',
+        'Buildkite::Pipelines::Steps::Input' => 'inputStep',
+        'Buildkite::Pipelines::Steps::Trigger' => 'triggerStep',
+        'Buildkite::Pipelines::Steps::Wait' => 'waitStep',
+        'Buildkite::Pipelines::Steps::Group' => 'groupStep',
+      }.freeze
 
       def initialize(schema_path: nil)
         path = schema_path || self.class.default_schema_path
@@ -26,8 +35,54 @@ module Buildkite
         @schemer.valid?(pipeline_hash)
       end
 
+      # Validates both the full pipeline and each step against its type-specific
+      # sub-schema. Step errors include source locations for precise error reporting.
+      def validate_all(pipeline_hash, step_collection = nil)
+        errors = validate(pipeline_hash)
+        if step_collection
+          step_hashes = pipeline_hash['steps'] || []
+          errors += validate_steps(step_hashes, step_collection.steps)
+        end
+        errors
+      end
+
       def self.default_schema_path
         File.expand_path('schema.json', __dir__)
+      end
+
+      private
+
+      def validate_steps(step_hashes, step_objects)
+        errors = []
+        step_hashes.each_with_index do |step_hash, index|
+          step_obj = step_objects[index]
+          next unless step_obj
+
+          errors.concat(validate_step(step_hash, step_obj))
+        end
+        errors
+      end
+
+      def validate_step(step_hash, step_obj)
+        if step_obj.is_a?(Pipelines::Steps::Group)
+          nested_hashes = step_hash['steps'] || []
+          nested_objects = step_obj.steps.steps
+          validate_steps(nested_hashes, nested_objects)
+        else
+          definition_name = STEP_SCHEMA_MAP[step_obj.class.name]
+          return [] unless definition_name
+
+          step_schemer = @schemer.ref("#/definitions/#{definition_name}")
+          return [] unless step_schemer
+
+          step_schemer.validate(step_hash).map do |error|
+            ValidationError.new(
+              pointer: error['data_pointer'],
+              message: error['error'],
+              source_location: step_obj.source_location
+            )
+          end
+        end
       end
     end
   end

--- a/lib/buildkite/pipelines/step_context.rb
+++ b/lib/buildkite/pipelines/step_context.rb
@@ -2,10 +2,13 @@
 
 module Buildkite
   module Pipelines
+    SourceLocation = Struct.new(:file, :line_number, keyword_init: true)
+
     class StepContext
       attr_reader :step
       attr_reader :args
       attr_reader :data
+      attr_accessor :source_location
 
       def initialize(step, **args)
         @step = step

--- a/lib/buildkite/pipelines/steps/abstract.rb
+++ b/lib/buildkite/pipelines/steps/abstract.rb
@@ -9,7 +9,7 @@ module Buildkite
         extend Forwardable
         include Attributes
 
-        def_delegator :@context, :data
+        def_delegators :@context, :data, :source_location
 
         def self.to_sym
           name.split('::').last.downcase.to_sym
@@ -20,6 +20,8 @@ module Buildkite
         end
 
         def process(block)
+          file, line = block.source_location
+          @context.source_location = SourceLocation.new(file: file, line_number: line) if file
           instance_exec(@context, &block)
         end
       end

--- a/spec/buildkite/builder/commands/abstract_spec.rb
+++ b/spec/buildkite/builder/commands/abstract_spec.rb
@@ -90,4 +90,29 @@ RSpec.describe Buildkite::Builder::Commands::Abstract do
       end
     end
   end
+
+  describe '#enforce_strict_default_migration!' do
+    let(:argv) { [] }
+
+    before do
+      stub_const('ARGV', argv)
+    end
+
+    it 'raises when the major version is >= 5' do
+      allow(Buildkite::Builder).to receive(:version).and_return('5.0.0')
+      fake = fake_command.new
+
+      expect {
+        fake.send(:enforce_strict_default_migration!)
+      }.to raise_error(RuntimeError, /Flip the default to strict/)
+    end
+
+    it 'does not raise for the current major version' do
+      fake = fake_command.new
+
+      expect {
+        fake.send(:enforce_strict_default_migration!)
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/buildkite/builder/commands/preview_spec.rb
+++ b/spec/buildkite/builder/commands/preview_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe Buildkite::Builder::Commands::Preview do
             Buildkite::Builder::Validator,
             validate_all: [
               Buildkite::Builder::Validator::ValidationError.new(
-                pointer: '/steps/0/timeout_in_minutes',
-                message: 'value is not an integer'
+                { 'data_pointer' => '/steps/0/timeout_in_minutes', 'error' => 'value is not an integer' }
               )
             ]
           )
@@ -81,8 +80,7 @@ RSpec.describe Buildkite::Builder::Commands::Preview do
             Buildkite::Builder::Validator,
             validate_all: [
               Buildkite::Builder::Validator::ValidationError.new(
-                pointer: '/steps/0/timeout_in_minutes',
-                message: 'value is not an integer'
+                { 'data_pointer' => '/steps/0/timeout_in_minutes', 'error' => 'value is not an integer' }
               )
             ]
           )

--- a/spec/buildkite/builder/commands/preview_spec.rb
+++ b/spec/buildkite/builder/commands/preview_spec.rb
@@ -54,9 +54,7 @@ RSpec.describe Buildkite::Builder::Commands::Preview do
         end
       end
 
-      context 'with --warn flag and an invalid pipeline' do
-        let(:argv) { ['--warn'] }
-
+      context 'with an invalid pipeline (default warn mode)' do
         it 'prints warnings to stderr but still outputs YAML' do
           bad_validator = instance_double(
             Buildkite::Builder::Validator,
@@ -72,6 +70,27 @@ RSpec.describe Buildkite::Builder::Commands::Preview do
           expect {
             described_class.execute
           }.to output(/steps:/).to_stdout
+        end
+      end
+
+      context 'with --strict flag and an invalid pipeline' do
+        let(:argv) { ['--strict'] }
+
+        it 'aborts without printing YAML' do
+          bad_validator = instance_double(
+            Buildkite::Builder::Validator,
+            validate_all: [
+              Buildkite::Builder::Validator::ValidationError.new(
+                pointer: '/steps/0/timeout_in_minutes',
+                message: 'value is not an integer'
+              )
+            ]
+          )
+          allow(Buildkite::Builder::Validator).to receive(:new).and_return(bad_validator)
+
+          expect {
+            described_class.execute
+          }.to raise_error(SystemExit)
         end
       end
     end

--- a/spec/buildkite/builder/commands/preview_spec.rb
+++ b/spec/buildkite/builder/commands/preview_spec.rb
@@ -31,5 +31,49 @@ RSpec.describe Buildkite::Builder::Commands::Preview do
         }.to raise_error(RuntimeError, 'Your project has multiple pipelines, please specify one.')
       end
     end
+
+    context 'validation integration' do
+      before do
+        setup_project(:basic)
+      end
+
+      it 'validates the pipeline and outputs YAML when valid' do
+        expect {
+          described_class.execute
+        }.to output(/steps:/).to_stdout
+      end
+
+      context 'with --no-validate flag' do
+        let(:argv) { ['--no-validate'] }
+
+        it 'skips validation and outputs YAML' do
+          expect(Buildkite::Builder::Validator).not_to receive(:new)
+          expect {
+            described_class.execute
+          }.to output(/steps:/).to_stdout
+        end
+      end
+
+      context 'with --warn flag and an invalid pipeline' do
+        let(:argv) { ['--warn'] }
+
+        it 'prints warnings to stderr but still outputs YAML' do
+          bad_validator = instance_double(
+            Buildkite::Builder::Validator,
+            validate_all: [
+              Buildkite::Builder::Validator::ValidationError.new(
+                pointer: '/steps/0/timeout_in_minutes',
+                message: 'value is not an integer'
+              )
+            ]
+          )
+          allow(Buildkite::Builder::Validator).to receive(:new).and_return(bad_validator)
+
+          expect {
+            described_class.execute
+          }.to output(/steps:/).to_stdout
+        end
+      end
+    end
   end
 end

--- a/spec/buildkite/builder/commands/run_spec.rb
+++ b/spec/buildkite/builder/commands/run_spec.rb
@@ -52,10 +52,7 @@ RSpec.describe Buildkite::Builder::Commands::Run do
             Buildkite::Builder::Validator,
             validate_all: [
               Buildkite::Builder::Validator::ValidationError.new(
-                pointer: '/timeout_in_minutes',
-                type: 'integer',
-                schema: { 'type' => 'integer' },
-                message: 'value is not an integer'
+                { 'data_pointer' => '/timeout_in_minutes', 'type' => 'integer', 'error' => 'value is not an integer' }
               )
             ]
           )

--- a/spec/buildkite/builder/commands/run_spec.rb
+++ b/spec/buildkite/builder/commands/run_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Buildkite::Builder::Commands::Run do
         it 'uploads the context' do
           expect(Buildkite::Builder::Pipeline).to receive(:new).and_return(pipeline)
           allow(pipeline).to receive(:to_h).and_return({ 'steps' => [] })
-          allow(pipeline).to receive_message_chain(:data, :steps, :steps).and_return([])
+          allow(pipeline).to receive(:steps).and_return(instance_double(Buildkite::Builder::StepCollection, steps: []))
           expect(pipeline).to receive(:upload)
 
           described_class.execute

--- a/spec/buildkite/builder/commands/run_spec.rb
+++ b/spec/buildkite/builder/commands/run_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Buildkite::Builder::Commands::Run do
 
         it 'uploads the context' do
           expect(Buildkite::Builder::Pipeline).to receive(:new).and_return(pipeline)
+          allow(pipeline).to receive(:to_h).and_return({ 'steps' => [] })
+          allow(pipeline).to receive_message_chain(:data, :steps, :steps).and_return([])
           expect(pipeline).to receive(:upload)
 
           described_class.execute

--- a/spec/buildkite/builder/commands/run_spec.rb
+++ b/spec/buildkite/builder/commands/run_spec.rb
@@ -41,6 +41,31 @@ RSpec.describe Buildkite::Builder::Commands::Run do
 
           described_class.execute
         end
+
+        it 'aborts without uploading when validation fails' do
+          expect(Buildkite::Builder::Pipeline).to receive(:new).and_return(pipeline)
+          allow(pipeline).to receive(:to_h).and_return({ 'steps' => [] })
+          allow(pipeline).to receive(:steps).and_return(instance_double(Buildkite::Builder::StepCollection, steps: []))
+
+          bad_validator = instance_double(
+            Buildkite::Builder::Validator,
+            validate_all: [
+              Buildkite::Builder::Validator::ValidationError.new(
+                pointer: '/timeout_in_minutes',
+                type: 'integer',
+                schema: { 'type' => 'integer' },
+                message: 'value is not an integer'
+              )
+            ]
+          )
+          allow(Buildkite::Builder::Validator).to receive(:new).and_return(bad_validator)
+
+          expect(pipeline).not_to receive(:upload)
+
+          expect {
+            described_class.execute
+          }.to raise_error(SystemExit)
+        end
       end
     end
   end

--- a/spec/buildkite/builder/commands/run_spec.rb
+++ b/spec/buildkite/builder/commands/run_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Buildkite::Builder::Commands::Run do
           described_class.execute
         end
 
-        it 'aborts without uploading when validation fails' do
+        it 'aborts without uploading when validation fails in strict mode' do
+          stub_const('ARGV', ['--strict'])
           expect(Buildkite::Builder::Pipeline).to receive(:new).and_return(pipeline)
           allow(pipeline).to receive(:to_h).and_return({ 'steps' => [] })
           allow(pipeline).to receive(:steps).and_return(instance_double(Buildkite::Builder::StepCollection, steps: []))

--- a/spec/buildkite/builder/commands/validate_spec.rb
+++ b/spec/buildkite/builder/commands/validate_spec.rb
@@ -20,50 +20,10 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
       end
     end
 
-    context 'with an invalid pipeline' do
+    context 'with an invalid pipeline (default warn mode)' do
       before do
         setup_project(:basic)
       end
-
-      it 'aborts with an error count' do
-        # Inject a validator that always returns errors
-        bad_validator = instance_double(
-          Buildkite::Builder::Validator,
-          validate_all: [
-            Buildkite::Builder::Validator::ValidationError.new(
-              pointer: '/timeout_in_minutes',
-              message: 'value at `/timeout_in_minutes` is not an integer'
-            )
-          ]
-        )
-        allow(Buildkite::Builder::Validator).to receive(:new).and_return(bad_validator)
-
-        expect {
-          described_class.execute
-        }.to raise_error(SystemExit)
-      end
-    end
-
-    context 'with a custom --schema flag' do
-      before do
-        setup_project(:basic)
-      end
-
-      let(:argv) { ['--schema', Buildkite::Builder::Validator.default_schema_path] }
-
-      it 'uses the specified schema and validates successfully' do
-        expect {
-          described_class.execute
-        }.to output(/Pipeline is valid\./).to_stdout
-      end
-    end
-
-    context 'with --warn flag and an invalid pipeline' do
-      before do
-        setup_project(:basic)
-      end
-
-      let(:argv) { ['--warn'] }
 
       it 'prints warnings without aborting' do
         bad_validator = instance_double(
@@ -82,6 +42,47 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
         expect {
           described_class.execute
         }.not_to raise_error
+      end
+    end
+
+    context 'with a custom --schema flag' do
+      before do
+        setup_project(:basic)
+      end
+
+      let(:argv) { ['--schema', Buildkite::Builder::Validator.default_schema_path] }
+
+      it 'uses the specified schema and validates successfully' do
+        expect {
+          described_class.execute
+        }.to output(/Pipeline is valid\./).to_stdout
+      end
+    end
+
+    context 'with --strict flag and an invalid pipeline' do
+      before do
+        setup_project(:basic)
+      end
+
+      let(:argv) { ['--strict'] }
+
+      it 'aborts with an error count' do
+        bad_validator = instance_double(
+          Buildkite::Builder::Validator,
+          validate_all: [
+            Buildkite::Builder::Validator::ValidationError.new(
+              pointer: '/timeout_in_minutes',
+              type: 'integer',
+              schema: { 'type' => 'integer' },
+              message: 'value is not an integer'
+            )
+          ]
+        )
+        allow(Buildkite::Builder::Validator).to receive(:new).and_return(bad_validator)
+
+        expect {
+          described_class.execute
+        }.to raise_error(SystemExit)
       end
     end
 

--- a/spec/buildkite/builder/commands/validate_spec.rb
+++ b/spec/buildkite/builder/commands/validate_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::Builder::Commands::Validate do
+  let(:argv) { [] }
+
+  before do
+    stub_const('ARGV', argv)
+  end
+
+  describe '.execute' do
+    context 'with a valid pipeline' do
+      before do
+        setup_project(:basic)
+      end
+
+      it 'prints success and exits cleanly' do
+        expect {
+          described_class.execute
+        }.to output(/Pipeline is valid\./).to_stdout
+      end
+    end
+
+    context 'with an invalid pipeline' do
+      before do
+        setup_project(:basic)
+      end
+
+      it 'aborts with an error count' do
+        # Inject a validator that always returns errors
+        bad_validator = instance_double(
+          Buildkite::Builder::Validator,
+          validate: [
+            Buildkite::Builder::Validator::ValidationError.new(
+              pointer: '/steps/0/timeout_in_minutes',
+              message: 'value at `/steps/0/timeout_in_minutes` is not an integer'
+            )
+          ]
+        )
+        allow(Buildkite::Builder::Validator).to receive(:new).and_return(bad_validator)
+
+        expect {
+          described_class.execute
+        }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'with a custom --schema flag' do
+      before do
+        setup_project(:basic)
+      end
+
+      let(:argv) { ['--schema', Buildkite::Builder::Validator.default_schema_path] }
+
+      it 'uses the specified schema and validates successfully' do
+        expect {
+          described_class.execute
+        }.to output(/Pipeline is valid\./).to_stdout
+      end
+    end
+
+    context 'when project has multiple pipelines' do
+      before do
+        setup_project(:multipipeline)
+      end
+
+      it 'requires specifying a pipeline' do
+        expect {
+          described_class.execute
+        }.to raise_error(RuntimeError, 'Your project has multiple pipelines, please specify one.')
+      end
+    end
+  end
+end

--- a/spec/buildkite/builder/commands/validate_spec.rb
+++ b/spec/buildkite/builder/commands/validate_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
         # Inject a validator that always returns errors
         bad_validator = instance_double(
           Buildkite::Builder::Validator,
-          validate: [
+          validate_all: [
             Buildkite::Builder::Validator::ValidationError.new(
-              pointer: '/steps/0/timeout_in_minutes',
-              message: 'value at `/steps/0/timeout_in_minutes` is not an integer'
+              pointer: '/timeout_in_minutes',
+              message: 'value at `/timeout_in_minutes` is not an integer'
             )
           ]
         )

--- a/spec/buildkite/builder/commands/validate_spec.rb
+++ b/spec/buildkite/builder/commands/validate_spec.rb
@@ -30,10 +30,7 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
           Buildkite::Builder::Validator,
           validate_all: [
             Buildkite::Builder::Validator::ValidationError.new(
-              pointer: '/timeout_in_minutes',
-              type: 'integer',
-              schema: { 'type' => 'integer' },
-              message: 'value is not an integer'
+              { 'data_pointer' => '/timeout_in_minutes', 'type' => 'integer', 'error' => 'value is not an integer' }
             )
           ]
         )
@@ -71,10 +68,7 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
           Buildkite::Builder::Validator,
           validate_all: [
             Buildkite::Builder::Validator::ValidationError.new(
-              pointer: '/timeout_in_minutes',
-              type: 'integer',
-              schema: { 'type' => 'integer' },
-              message: 'value is not an integer'
+              { 'data_pointer' => '/timeout_in_minutes', 'type' => 'integer', 'error' => 'value is not an integer' }
             )
           ]
         )

--- a/spec/buildkite/builder/commands/validate_spec.rb
+++ b/spec/buildkite/builder/commands/validate_spec.rb
@@ -58,6 +58,33 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
       end
     end
 
+    context 'with --warn flag and an invalid pipeline' do
+      before do
+        setup_project(:basic)
+      end
+
+      let(:argv) { ['--warn'] }
+
+      it 'prints warnings without aborting' do
+        bad_validator = instance_double(
+          Buildkite::Builder::Validator,
+          validate_all: [
+            Buildkite::Builder::Validator::ValidationError.new(
+              pointer: '/timeout_in_minutes',
+              type: 'integer',
+              schema: { 'type' => 'integer' },
+              message: 'value is not an integer'
+            )
+          ]
+        )
+        allow(Buildkite::Builder::Validator).to receive(:new).and_return(bad_validator)
+
+        expect {
+          described_class.execute
+        }.not_to raise_error
+      end
+    end
+
     context 'when project has multiple pipelines' do
       before do
         setup_project(:multipipeline)

--- a/spec/buildkite/builder/commands/validate_spec.rb
+++ b/spec/buildkite/builder/commands/validate_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
       it 'prints success and exits cleanly' do
         expect {
           described_class.execute
-        }.to output(/Pipeline is valid\./).to_stdout
+        }.to output(/Pipeline is valid\./).to_stderr
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Buildkite::Builder::Commands::Validate do
       it 'uses the specified schema and validates successfully' do
         expect {
           described_class.execute
-        }.to output(/Pipeline is valid\./).to_stdout
+        }.to output(/Pipeline is valid\./).to_stderr
       end
     end
 

--- a/spec/buildkite/builder/matchers_spec.rb
+++ b/spec/buildkite/builder/matchers_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'buildkite/builder/matchers'
+
+RSpec.describe Buildkite::Builder::Matchers do
+  include Buildkite::Builder::Matchers
+
+  describe 'be_valid_pipeline' do
+    context 'with a valid pipeline hash' do
+      let(:pipeline_hash) { { 'steps' => [{ 'command' => 'echo hello', 'label' => 'test' }] } }
+
+      it 'passes' do
+        expect(pipeline_hash).to be_valid_pipeline
+      end
+    end
+
+    context 'with an invalid pipeline hash' do
+      let(:pipeline_hash) { {} }
+
+      it 'fails with an error message listing the violations' do
+        expect {
+          expect(pipeline_hash).to be_valid_pipeline
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected pipeline to be valid/)
+      end
+
+      it 'includes error count in the failure message' do
+        expect {
+          expect(pipeline_hash).to be_valid_pipeline
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /error\(s\)/)
+      end
+    end
+
+    context 'with .with_schema chained' do
+      let(:pipeline_hash) { { 'steps' => [{ 'command' => 'echo hello' }] } }
+      let(:default_schema) { Buildkite::Builder::Validator.default_schema_path }
+
+      it 'uses the specified schema' do
+        expect(pipeline_hash).to be_valid_pipeline.with_schema(default_schema)
+      end
+    end
+
+    context 'with a real fixture pipeline' do
+      before { setup_project(:basic) }
+
+      it 'validates a real pipeline built from DSL' do
+        pipeline_path = fixture_pipeline_path_for(:basic, :dummy)
+        pipeline_hash = Buildkite::Builder::Pipeline.new(pipeline_path).to_h
+        expect(pipeline_hash).to be_valid_pipeline
+      end
+    end
+  end
+end

--- a/spec/buildkite/builder/validator_spec.rb
+++ b/spec/buildkite/builder/validator_spec.rb
@@ -68,11 +68,9 @@ RSpec.describe Buildkite::Builder::Validator do
 
     it 'returns per-step errors with source locations when a step is invalid' do
       hash = pipeline.to_h
-      # Inject an invalid timeout to simulate a per-step schema violation
       hash['steps'][0]['timeout_in_minutes'] = 'not-a-number'
 
       errors = validator.validate_all(hash, pipeline.data.steps)
-      # Per-step errors carry source_location; pipeline-level errors do not
       step_errors = errors.select { |e| e.source_location }
 
       expect(step_errors).not_to be_empty
@@ -84,6 +82,111 @@ RSpec.describe Buildkite::Builder::Validator do
     it 'works without a step collection (falls back to pipeline-level errors only)' do
       errors = validator.validate_all({})
       expect(errors).not_to be_empty
+    end
+
+    it 'validates nested steps inside a group step' do
+      setup_project(:multipipeline)
+      group_pipeline = Buildkite::Builder::Pipeline.new(fixture_pipeline_path_for(:multipipeline, :dummy1))
+      hash = group_pipeline.to_h
+
+      # Build a group hash with an invalid nested step
+      group_hash = { 'group' => nil, 'steps' => [{ 'command' => 'echo', 'timeout_in_minutes' => 'bad' }] }
+      hash['steps'] = [group_hash]
+
+      # Build a matching group step object with a nested command step
+      group_step = instance_double(
+        Buildkite::Pipelines::Steps::Group,
+        source_location: nil
+      )
+      allow(group_step).to receive(:is_a?).with(Buildkite::Pipelines::Steps::Group).and_return(true)
+
+      inner_step = instance_double(
+        Buildkite::Pipelines::Steps::Command,
+        source_location: Buildkite::Pipelines::SourceLocation.new(file: 'pipeline.rb', line_number: 5),
+        class: Buildkite::Pipelines::Steps::Command
+      )
+      allow(inner_step).to receive(:is_a?).with(Buildkite::Pipelines::Steps::Group).and_return(false)
+
+      inner_collection = instance_double(Buildkite::Builder::StepCollection, steps: [inner_step])
+      allow(group_step).to receive(:steps).and_return(inner_collection)
+
+      step_collection = instance_double(Buildkite::Builder::StepCollection, steps: [group_step])
+      errors = validator.validate_all(hash, step_collection)
+      step_errors = errors.select { |e| e.source_location }
+
+      expect(step_errors).not_to be_empty
+      expect(step_errors.first.source_location.file).to eq('pipeline.rb')
+    end
+  end
+
+  describe Buildkite::Builder::Validator::ValidationError do
+    describe '#attribute' do
+      it 'returns the last segment of the pointer' do
+        error = described_class.new(pointer: '/steps/0/timeout_in_minutes')
+        expect(error.attribute).to eq('timeout_in_minutes')
+      end
+
+      it 'returns "pipeline" when pointer is empty' do
+        error = described_class.new(pointer: '')
+        expect(error.attribute).to eq('pipeline')
+      end
+    end
+
+    describe '#formatted_message' do
+      it 'formats integer type errors with correct article' do
+        error = described_class.new(type: 'integer', schema: { 'type' => 'integer' })
+        expect(error.formatted_message).to eq('must be an integer')
+      end
+
+      it 'formats string type errors with correct article' do
+        error = described_class.new(type: 'string', schema: { 'type' => 'string' })
+        expect(error.formatted_message).to eq('must be a string')
+      end
+
+      it 'formats enum errors listing allowed values' do
+        error = described_class.new(type: 'enum', schema: { 'enum' => ['ordered', 'eager'] })
+        expect(error.formatted_message).to eq('must be one of: "ordered", "eager"')
+      end
+
+      it 'formats required errors using details missing_keys' do
+        error = described_class.new(
+          type: 'required',
+          schema: { 'required' => %w[steps env] },
+          details: { 'missing_keys' => ['steps'] }
+        )
+        expect(error.formatted_message).to eq('is missing required attributes: steps')
+      end
+
+      it 'formats additionalProperties errors as unrecognized attribute' do
+        error = described_class.new(type: 'schema', schema: {})
+        expect(error.formatted_message).to eq('is not a recognized attribute')
+      end
+
+      it 'falls back to raw message for unknown error types' do
+        error = described_class.new(type: 'custom_thing', schema: {}, message: 'something went wrong')
+        expect(error.formatted_message).to eq('something went wrong')
+      end
+    end
+
+    describe '#to_s' do
+      it 'includes source location when present' do
+        error = described_class.new(
+          pointer: '/timeout_in_minutes',
+          type: 'integer',
+          schema: { 'type' => 'integer' },
+          source_location: Buildkite::Pipelines::SourceLocation.new(file: 'pipeline.rb', line_number: 42)
+        )
+        expect(error.to_s).to eq("pipeline.rb:42 'timeout_in_minutes': must be an integer")
+      end
+
+      it 'omits location prefix when source_location is nil' do
+        error = described_class.new(
+          pointer: '/timeout_in_minutes',
+          type: 'integer',
+          schema: { 'type' => 'integer' }
+        )
+        expect(error.to_s).to eq("'timeout_in_minutes': must be an integer")
+      end
     end
   end
 

--- a/spec/buildkite/builder/validator_spec.rb
+++ b/spec/buildkite/builder/validator_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::Builder::Validator do
+  subject(:validator) { described_class.new }
+
+  describe '#valid?' do
+    it 'returns true for a valid pipeline' do
+      pipeline = { 'steps' => [{ 'command' => 'echo hello', 'label' => 'test' }] }
+      expect(validator.valid?(pipeline)).to be true
+    end
+
+    it 'returns false when steps key is missing' do
+      expect(validator.valid?({})).to be false
+    end
+
+    it 'returns false for an invalid step property type' do
+      pipeline = { 'steps' => [{ 'command' => 'echo hello', 'timeout_in_minutes' => 'thirty' }] }
+      expect(validator.valid?(pipeline)).to be false
+    end
+  end
+
+  describe '#validate' do
+    it 'returns an empty array for a valid pipeline' do
+      pipeline = { 'steps' => [{ 'command' => 'echo hello', 'label' => 'test' }] }
+      expect(validator.validate(pipeline)).to be_empty
+    end
+
+    it 'returns ValidationError objects with pointer and message for invalid pipeline' do
+      errors = validator.validate({})
+      expect(errors).not_to be_empty
+      expect(errors.first).to be_a(Buildkite::Builder::Validator::ValidationError)
+      expect(errors.first.pointer).to be_a(String)
+      expect(errors.first.message).to be_a(String)
+    end
+
+    it 'reports the correct pointer for an invalid step property' do
+      pipeline = { 'steps' => [{ 'command' => 'echo hello', 'timeout_in_minutes' => 'thirty' }] }
+      errors = validator.validate(pipeline)
+      expect(errors).not_to be_empty
+      expect(errors.any? { |e| e.pointer.include?('timeout_in_minutes') }).to be true
+    end
+
+    it 'accepts a custom schema path' do
+      custom_validator = described_class.new(schema_path: described_class.default_schema_path)
+      pipeline = { 'steps' => [{ 'command' => 'echo hello' }] }
+      expect(custom_validator.valid?(pipeline)).to be true
+    end
+  end
+
+  describe '.default_schema_path' do
+    it 'returns a path to an existing file' do
+      expect(File.exist?(described_class.default_schema_path)).to be true
+    end
+  end
+
+  describe 'compatibility with fixture pipeline output' do
+    before { setup_project(:basic) }
+
+    it 'validates the basic fixture pipeline without errors' do
+      pipeline_path = fixture_pipeline_path_for(:basic, :dummy)
+      pipeline_hash = Buildkite::Builder::Pipeline.new(pipeline_path).to_h
+      errors = validator.validate(pipeline_hash)
+      expect(errors).to be_empty, "Expected no validation errors but got:\n#{errors.map { |e| "  #{e.pointer}: #{e.message}" }.join("\n")}"
+    end
+  end
+end

--- a/spec/buildkite/builder/validator_spec.rb
+++ b/spec/buildkite/builder/validator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Buildkite::Builder::Validator do
       expect(errors).not_to be_empty
       expect(errors.first).to be_a(Buildkite::Builder::Validator::ValidationError)
       expect(errors.first.pointer).to be_a(String)
-      expect(errors.first.message).to be_a(String)
+      expect(errors.first.formatted_message).to be_a(String)
     end
 
     it 'reports the correct pointer for an invalid step property' do
@@ -122,92 +122,78 @@ RSpec.describe Buildkite::Builder::Validator do
   describe Buildkite::Builder::Validator::ValidationError do
     describe '#attribute' do
       it 'returns the last segment of the pointer' do
-        error = described_class.new(pointer: '/steps/0/timeout_in_minutes')
+        error = described_class.new({ 'data_pointer' => '/steps/0/timeout_in_minutes' })
         expect(error.attribute).to eq('timeout_in_minutes')
       end
 
       it 'returns "pipeline" when pointer is empty' do
-        error = described_class.new(pointer: '')
+        error = described_class.new({ 'data_pointer' => '' })
         expect(error.attribute).to eq('pipeline')
       end
     end
 
     describe '#formatted_message' do
       it 'formats integer type errors with correct article' do
-        error = described_class.new(type: 'integer', schema: { 'type' => 'integer' })
+        error = described_class.new({ 'type' => 'integer' })
         expect(error.formatted_message).to eq('must be an integer')
       end
 
       it 'formats string type errors with correct article' do
-        error = described_class.new(type: 'string', schema: { 'type' => 'string' })
+        error = described_class.new({ 'type' => 'string' })
         expect(error.formatted_message).to eq('must be a string')
       end
 
       it 'formats enum errors listing allowed values' do
-        error = described_class.new(type: 'enum', schema: { 'enum' => ['ordered', 'eager'] })
+        error = described_class.new({ 'type' => 'enum', 'schema' => { 'enum' => ['ordered', 'eager'] } })
         expect(error.formatted_message).to eq('must be one of: "ordered", "eager"')
       end
 
       it 'formats required errors using details missing_keys' do
-        error = described_class.new(
-          type: 'required',
-          schema: { 'required' => %w[steps env] },
-          details: { 'missing_keys' => ['steps'] }
-        )
+        error = described_class.new({ 'type' => 'required', 'schema' => { 'required' => %w[steps env] }, 'details' => { 'missing_keys' => ['steps'] } })
         expect(error.formatted_message).to eq('is missing required attributes: steps')
       end
 
       it 'formats additionalProperties errors as unrecognized attribute' do
-        error = described_class.new(type: 'schema', schema: {})
+        error = described_class.new({ 'type' => 'schema' })
         expect(error.formatted_message).to eq('is not a recognized attribute')
       end
 
       it 'formats minimum errors with threshold' do
-        error = described_class.new(type: 'minimum', schema: { 'minimum' => 1 })
+        error = described_class.new({ 'type' => 'minimum', 'schema' => { 'minimum' => 1 } })
         expect(error.formatted_message).to eq('must be at least 1')
       end
 
       it 'formats maximum errors with threshold' do
-        error = described_class.new(type: 'maximum', schema: { 'maximum' => 10 })
+        error = described_class.new({ 'type' => 'maximum', 'schema' => { 'maximum' => 10 } })
         expect(error.formatted_message).to eq('must be at most 10')
       end
 
       it 'formats pattern errors' do
-        error = described_class.new(type: 'pattern', schema: { 'pattern' => '^[a-z]+$' })
+        error = described_class.new({ 'type' => 'pattern' })
         expect(error.formatted_message).to eq('does not match expected format')
       end
 
       it 'formats minItems errors with count' do
-        error = described_class.new(type: 'minItems', schema: { 'minItems' => 1 })
+        error = described_class.new({ 'type' => 'minItems', 'schema' => { 'minItems' => 1 } })
         expect(error.formatted_message).to eq('must have at least 1 item(s)')
       end
 
       it 'falls back to raw message for unknown error types' do
-        error = described_class.new(type: 'custom_thing', schema: {}, message: 'something went wrong')
+        error = described_class.new({ 'type' => 'custom_thing', 'error' => 'something went wrong' })
         expect(error.formatted_message).to eq('something went wrong')
       end
     end
 
     describe '#to_s' do
       it 'includes source location when present' do
-        error = described_class.new(
-          pointer: '/timeout_in_minutes',
-          type: 'integer',
-          schema: { 'type' => 'integer' },
-          source_location: Buildkite::Pipelines::SourceLocation.new(file: 'pipeline.rb', line_number: 42)
-        )
-        output = Rainbow::StringUtils.uncolor(error.to_s)
-        expect(output).to eq("pipeline.rb:42 timeout_in_minutes: must be an integer")
+        loc = Buildkite::Pipelines::SourceLocation.new(file: 'pipeline.rb', line_number: 42)
+        error = described_class.new({ 'data_pointer' => '/timeout_in_minutes', 'type' => 'integer' }, source_location: loc)
+        expect(Rainbow::StringUtils.uncolor(error.to_s)).to eq("pipeline.rb:42 timeout_in_minutes: must be an integer")
       end
 
       it 'omits location prefix when source_location is nil' do
-        error = described_class.new(
-          pointer: '/timeout_in_minutes',
-          type: 'integer',
-          schema: { 'type' => 'integer' }
-        )
-        output = Rainbow::StringUtils.uncolor(error.to_s)
-        expect(output).to eq("timeout_in_minutes: must be an integer")
+        error = described_class.new({ 'data_pointer' => '/timeout_in_minutes', 'type' => 'integer' })
+        expect(Rainbow::StringUtils.uncolor(error.to_s)).to eq("timeout_in_minutes: must be an integer")
       end
     end
   end

--- a/spec/buildkite/builder/validator_spec.rb
+++ b/spec/buildkite/builder/validator_spec.rb
@@ -196,7 +196,8 @@ RSpec.describe Buildkite::Builder::Validator do
           schema: { 'type' => 'integer' },
           source_location: Buildkite::Pipelines::SourceLocation.new(file: 'pipeline.rb', line_number: 42)
         )
-        expect(error.to_s).to eq("pipeline.rb:42 'timeout_in_minutes': must be an integer")
+        output = Rainbow::StringUtils.uncolor(error.to_s)
+        expect(output).to eq("pipeline.rb:42 timeout_in_minutes: must be an integer")
       end
 
       it 'omits location prefix when source_location is nil' do
@@ -205,7 +206,8 @@ RSpec.describe Buildkite::Builder::Validator do
           type: 'integer',
           schema: { 'type' => 'integer' }
         )
-        expect(error.to_s).to eq("'timeout_in_minutes': must be an integer")
+        output = Rainbow::StringUtils.uncolor(error.to_s)
+        expect(output).to eq("timeout_in_minutes: must be an integer")
       end
     end
   end

--- a/spec/buildkite/builder/validator_spec.rb
+++ b/spec/buildkite/builder/validator_spec.rb
@@ -162,6 +162,26 @@ RSpec.describe Buildkite::Builder::Validator do
         expect(error.formatted_message).to eq('is not a recognized attribute')
       end
 
+      it 'formats minimum errors with threshold' do
+        error = described_class.new(type: 'minimum', schema: { 'minimum' => 1 })
+        expect(error.formatted_message).to eq('must be at least 1')
+      end
+
+      it 'formats maximum errors with threshold' do
+        error = described_class.new(type: 'maximum', schema: { 'maximum' => 10 })
+        expect(error.formatted_message).to eq('must be at most 10')
+      end
+
+      it 'formats pattern errors' do
+        error = described_class.new(type: 'pattern', schema: { 'pattern' => '^[a-z]+$' })
+        expect(error.formatted_message).to eq('does not match expected format')
+      end
+
+      it 'formats minItems errors with count' do
+        error = described_class.new(type: 'minItems', schema: { 'minItems' => 1 })
+        expect(error.formatted_message).to eq('must have at least 1 item(s)')
+      end
+
       it 'falls back to raw message for unknown error types' do
         error = described_class.new(type: 'custom_thing', schema: {}, message: 'something went wrong')
         expect(error.formatted_message).to eq('something went wrong')

--- a/spec/buildkite/builder/validator_spec.rb
+++ b/spec/buildkite/builder/validator_spec.rb
@@ -53,6 +53,40 @@ RSpec.describe Buildkite::Builder::Validator do
     end
   end
 
+  describe '#validate_all' do
+    before { setup_project(:basic) }
+
+    let(:pipeline) do
+      Buildkite::Builder::Pipeline.new(fixture_pipeline_path_for(:basic, :dummy))
+    end
+
+    it 'returns no errors for a valid pipeline' do
+      hash = pipeline.to_h
+      errors = validator.validate_all(hash, pipeline.data.steps)
+      expect(errors).to be_empty, "Expected no errors but got:\n#{errors.map { |e| "  #{e.pointer}: #{e.message}" }.join("\n")}"
+    end
+
+    it 'returns per-step errors with source locations when a step is invalid' do
+      hash = pipeline.to_h
+      # Inject an invalid timeout to simulate a per-step schema violation
+      hash['steps'][0]['timeout_in_minutes'] = 'not-a-number'
+
+      errors = validator.validate_all(hash, pipeline.data.steps)
+      # Per-step errors carry source_location; pipeline-level errors do not
+      step_errors = errors.select { |e| e.source_location }
+
+      expect(step_errors).not_to be_empty
+      expect(step_errors.first.source_location).to be_a(Buildkite::Pipelines::SourceLocation)
+      expect(step_errors.first.source_location.file).to include('.rb')
+      expect(step_errors.first.source_location.line_number).to be_an(Integer)
+    end
+
+    it 'works without a step collection (falls back to pipeline-level errors only)' do
+      errors = validator.validate_all({})
+      expect(errors).not_to be_empty
+    end
+  end
+
   describe 'compatibility with fixture pipeline output' do
     before { setup_project(:basic) }
 

--- a/spec/buildkite/pipelines/steps/abstract_spec.rb
+++ b/spec/buildkite/pipelines/steps/abstract_spec.rb
@@ -24,5 +24,27 @@ RSpec.describe Buildkite::Pipelines::Steps::Abstract do
       expect(step.foo_attribute).to eq('1')
       expect(step.bar_attribute).to eq('2')
     end
+
+    it 'captures the source location of the block' do
+      block = proc { foo_attribute '1' }
+      expected_file, expected_line = block.source_location
+
+      step.process(block)
+
+      expect(step.source_location).to be_a(Buildkite::Pipelines::SourceLocation)
+      expect(step.source_location.file).to eq(expected_file)
+      expect(step.source_location.line_number).to eq(expected_line)
+    end
+
+    it 'overwrites source location when processing multiple blocks' do
+      first_block = proc { foo_attribute '1' }
+      second_block = proc { bar_attribute '2' }
+      _, second_line = second_block.source_location
+
+      step.process(first_block)
+      step.process(second_block)
+
+      expect(step.source_location.line_number).to eq(second_line)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,13 @@
+require 'simplecov'
+require 'simplecov_json_formatter'
+
+SimpleCov.start do
+  formatter SimpleCov::Formatter::JSONFormatter
+  add_filter '/spec/'
+  add_filter '/vendor/'
+  enable_coverage :branch
+end
+
 require 'bundler/setup'
 require 'buildkite-builder'
 require 'debug'


### PR DESCRIPTION
> [!NOTE]
> **+789, -6** without the vendored JSON schema — I did my best to keep the diff manageable! 😭 

## Why

When a buildkite-builder pipeline produces invalid output, authors don't find out until Buildkite rejects the upload with an opaque "pipeline upload failed" error and no indication of what's wrong or where. This creates a painful edit-push-wait-guess iteration loop — especially problematic for AI agents that can't pattern-match on vague errors and need structured feedback to self-correct.

## What

Adds pipeline schema validation using the [official Buildkite pipeline schema](https://github.com/buildkite/pipeline-schema) and the `json_schemer` gem.

**New `validate` command:**
```
buildkite-builder validate [PIPELINE]
```

**Validation built into `run` and `preview`** (warn mode by default, `--strict` to fail):
```
Validating pipeline
│ pipeline.rb:2 timeout_in_minutes: must be an integer
│ pipeline.rb:8 concurrency: must be an integer
└── 2 warnings. Pass --strict to fail on validation errors.
```

**RSpec `be_valid_pipeline` matcher:**
```ruby
expect(pipeline.to_h).to be_valid_pipeline
```

**Two-layer validation:**
1. Full pipeline validation against the top-level schema (catches missing `steps`, etc.)
2. Per-step validation against type-specific sub-schemas (`commandStep`, `blockStep`, etc.) with source locations pointing back to the pipeline DSL

**Output design follows existing gem conventions** — tree-style with `│` / `└──` connectors, dimgray/bright/yellow coloring matching the extension processing output.

## Notes for reviewers

**Warn-by-default with migration path.** Validation currently warns instead of failing, with a notice that `--strict` will become the default in the next major release. `enforce_strict_default_migration!` raises at dev time when the major version reaches 5, ensuring we don't forget to flip the default. This gives existing consumers a no-surprise upgrade path.

**Schema vendored at `lib/buildkite/builder/schema.json`**, pinned to a specific upstream version. Auto-included by the gemspec's `lib/**/*` glob. The schema compilation is cached at the class level and warnings from its regex patterns are suppressed.

**`ValidationError` wraps the raw json_schemer error hash** rather than deconstructing it into fields. Only `pointer` and `source_location` are public readers; `formatted_message` reads from the hash internally. Error formatting uses structured fields (`error['type']`, `error['schema']`) instead of regex-parsing the message string.

**Per-step validation uses `@schemer.ref('#/definitions/commandStep')` etc.** after serialization (sanitized, string-keyed hash) to avoid false positives from the schema's `additionalProperties: false`. Step errors from the full-pipeline pass are suppressed when per-step validation runs to avoid duplicate reporting.

**Source locations** are captured via `block.source_location` in `Abstract#process` and stored as `Pipelines::SourceLocation` structs (file, line_number). The last-processed block wins (DSL block overrides template block), pointing to the author's code rather than library internals.
